### PR TITLE
feat: add support for options handling and an action button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minui list
 
-This is a minui list app. It allows people to show a list of items and then writes the selected item to stdout.
+This is a minui list app. It allows people to show a list of items or settings and then writes the selected item or state to stdout.
 
 ## Requirements
 
@@ -46,7 +46,7 @@ output=$(minui-list --file list.json)
 minui-list --file list.json --header "Some Header"
 
 # specify alternative text for the Confirm button
-# by default, the Confirm button is "SELECT"
+# by default, the Confirm button text is "SELECT"
 minui-list --file list.json --confirm-text "CHOOSE"
 
 # specify an alternative button for the Confirm button
@@ -55,13 +55,32 @@ minui-list --file list.json --confirm-text "CHOOSE"
 minui-list --file list.json --confirm-button "X"
 
 # specify alternative text for the Cancel button
-# by default, the Cancel button is "BACK"
+# by default, the Cancel button text is "BACK"
 minui-list --file list.json --cancel-text "CANCEL"
 
 # specify an alternative button for the Cancel button
 # by default, the Cancel button is "B"
 # the only buttons supported are "A", "B", "X", and "Y"
 minui-list --file list.json --cancel-button "Y"
+
+# specify a button for the Action Button
+# by default, there is no action button
+# when set, the default Action button text is "ACTION"
+# the only buttons supported are "A", "B", "X", and "Y"
+minui-list --file list.json --action-button "X" --action-text "RESUME"
+
+# specify an alternative button for the Enable Button
+# by default, the Cancel button is "Y"
+# the button text is either "Enable" or "Disable"
+# the only buttons supported are "A", "B", "X", and "Y"
+minui-list --file list.json --enable-button "Y"
+
+# write the current json state to stdout
+# this will _always_ write the current state to stdout
+# regardless of exit code
+# the index of the selected item will be written
+# to the top-level `selected` property
+minui-list --file list.json --stdout-value state
 ```
 
 To create a list of items from newline-delimited strings, you can use jq:
@@ -81,12 +100,69 @@ done < items.txt | sed '$ s/,$//' >> list.json
 printf ']\n' >> list.json
 ```
 
+### File Formats
+
+#### Text
+
+A newline-delimited file.
+
+```text
+item 1
+item 2
+item 3
+```
+
+#### JSON
+
+##### Array
+
+A json array. May or may not be formatted.
+
+```json
+[
+  "item 1",
+  "item 2",
+  "item 3"
+]
+```
+
+##### Object
+
+A list of objects set at a particular key. May or may not be formatted.
+
+```json
+{
+  "items": [
+    {
+      "name": "item 1"
+    },
+    {
+      "name": "item 2"
+    },
+    {
+      "name": "item 3"
+    }
+  ]
+}
+```
+
+Properties:
+
+- name: (required, type: `string`) the option name
+- enabled: (optional, type: `boolean`, default: `true`) whether the field shows up as enabled or disabled
+- options: (optional, type: `[]string`, default: `[]`) a list of strings to display as options
+- selected_option: (optional, type: `integer`, default: `0`) the default selected option
+- supports_enabling: (optional, type: `boolean`, default: `false`) whether or not an option can be enabled or disabled
+
 ### Exit Codes
 
 - 0: Success (the user selected an item)
 - 1: Error
 - 2: User cancelled with B button
 - 3: User cancelled with Menu button
+- 4: User pressed Action button
+- 10: Error parsing input
+- 11: Error serializing output
 - 130: Ctrl+C
 
 ## Screenshots


### PR DESCRIPTION
This PR adds support for specifying specific options when processing json input. If any items have options, the left/right buttons turn into option selectors for the whole list (this is a no-op for items that have no options). The item name and the currently selected option are delimited by a `:`. The default selected option is at index 0, and this can be changed via `selected_option` (invalid values will be corrected, with a message on stdout).

Any list item can have the optional field `enabled` set to `false` (default: `true`), which will disable the ability to change the option value. Items can have an optional field `supports_enabling` set to `true` (default: false) to provide the ability to enable or disable an item. Disabled items will be displayed in gray. A new `--enabled-button` (default: Y) flag _must_ be set in order to provide functionality for enabling and disabling items.

Additionally, a new flag named `--stdout-value` can be used to decide whether to output the currently `selected` item (default) or the entire `state`. If the entire state is used, the output is written as pretty-printed json. If the `--stdout-value` flag is set to `state`, then the state is written to stdout regardless of the exit code.

Finally, an action key is introduced. This can be mapped to any of A/B/X/Y via the `--action-button` flag (default: X), and custom text can be specified for the action (default: ACTION). The selected value will also be output to stdout if `--stdout-value` flag is set to `selected`.

Closes #7