### PR TITLE
chore: remove --header flag parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ output=$(minui-list --file list.json)
 # depending on platform, so this may be useful
 minui-list --write-location file.txt
 
-# specify a title for the list page (replaces --header in previous versions)
+# specify a title for the list page
 # by default, the title is empty
 minui-list --file list.json --title "Some Title"
 

--- a/minui-list.c
+++ b/minui-list.c
@@ -1659,7 +1659,6 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         {"font-medium", required_argument, 0, 'M'},
         {"format", required_argument, 0, 'F'},
         {"item-key", required_argument, 0, 'i'},
-        {"header", required_argument, 0, 'H'},
         {"title", required_argument, 0, 't'},
         {"title-alignment", required_argument, 0, 'T'},
         {"write-location", required_argument, 0, 'w'},
@@ -1667,7 +1666,6 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         {0, 0, 0, 0}};
 
     int opt;
-    char *header_arg = NULL;
     char *font_path_default = NULL;
     char *font_path_large = NULL;
     char *font_path_medium = NULL;
@@ -1711,9 +1709,6 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         case 'i':
             strncpy(state->item_key, optarg, sizeof(state->item_key) - 1);
             break;
-        case 'H':
-            header_arg = optarg;
-            break;
         case 't':
             strncpy(state->title, optarg, sizeof(state->title) - 1);
             break;
@@ -1735,18 +1730,6 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         default:
             return false;
         }
-    }
-
-    // If we already have a title, don't overwrite it with the --header argument. Log an error and return false if both are provided
-    if (header_arg != NULL && strlen(state->title) > 0)
-    {
-        log_error("Both --header and --title arguments provided. Please use only one.");
-        return false;
-    }
-    else if (header_arg != NULL)
-    {
-        // --header was used instead of --title
-        log_error("WARNING: The --header flag has been replaced by --title. Please use --title instead.");
     }
 
     // validate title alignment


### PR DESCRIPTION
It is supersceded by --title.