### PR TITLE
feat: add support for the h700 platform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         toolchain:
           # - gkdpixel deprecated, but also i386 only so it won't build without buildx
+          - h700
           - m17 # (deprecated)
           - magicmini
           - miyoomini # (deprecated)
@@ -38,6 +39,8 @@ jobs:
           - trimuismart # (deprecated)
           - zero28
         include:
+          - toolchain: h700
+            toolchain_repo: LoveRetro/h700-toolchain
           - toolchain: tg5050
             toolchain_repo: LoveRetro/tg5050-toolchain
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         toolchain:
           # - gkdpixel deprecated, but also i386 only so it won't build without buildx
+          - h700
           - m17 # (deprecated)
           - magicmini
           - miyoomini # (deprecated)
@@ -43,6 +44,8 @@ jobs:
           - trimuismart # (deprecated)
           - zero28
         include:
+          - toolchain: h700
+            toolchain_repo: LoveRetro/h700-toolchain
           - toolchain: tg5050
             toolchain_repo: LoveRetro/tg5050-toolchain
     outputs:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ CURRENT_WORKING_DIR = $(shell pwd)
 PLATFORM ?= tg5040
 MINUI_VERSION ?= v20251023-0
 NEXTUI_VERSION ?= v6.9.0
+H700_VERSION ?= h700-rc3
 
 # Determine upstream repository based on platform
 ifeq ($(PLATFORM),tg5050)
   UPSTREAM_REPO = https://github.com/loveRetro/NextUI
   UPSTREAM_VERSION = $(NEXTUI_VERSION)
+else ifeq ($(PLATFORM),h700)
+  UPSTREAM_REPO = https://github.com/pvaibhav/NextUI
+  UPSTREAM_VERSION = $(H700_VERSION)
 else
   UPSTREAM_REPO = https://github.com/shauninman/MinUI
   UPSTREAM_VERSION = $(MINUI_VERSION)
@@ -48,10 +52,16 @@ else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
   SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
-  # tg5050 uses NextUI toolchain which installs libmsettings to /opt/nextui
-  ifeq ($(PLATFORM),tg5050)
+  # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
+  ifneq (,$(filter $(PLATFORM),tg5050 h700))
     INCDIR += -I/opt/nextui/include
-    FLAGS += -L/opt/nextui/lib -lGLESv2 -lmali -lsamplerate
+    # tg5050's GLESv2 is backed by a separate mali blob that must be linked
+    # explicitly; h700 links libGLESv2 directly and ships no standalone libmali
+    NEXTUI_GL_LIBS = -lGLESv2 -lsamplerate
+    ifeq ($(PLATFORM),tg5050)
+      NEXTUI_GL_LIBS = -lGLESv2 -lmali -lsamplerate
+    endif
+    FLAGS += -L/opt/nextui/lib $(NEXTUI_GL_LIBS)
     CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DPLATFORM_NEXTUI
     SOURCE += minui/workspace/all/common/config.c
   else


### PR DESCRIPTION
Closes #117.

The H700 is a NextUI-based platform, mirroring how `tg5050` was previously added. Because neither upstream NextUI nor the existing forks ship an H700 workspace, the `h700` target clones its platform source from the `pvaibhav/NextUI` fork at the `h700-rc3` tag and builds against the `LoveRetro/h700-toolchain` image.