### PR TITLE
fix: keep letter-jump selection on screen when wrapping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Move the codebase to the correct location
         run: |
           mkdir -p union-${{ matrix.toolchain }}-toolchain/workspace/repo
-          mv *.c Makefile union-${{ matrix.toolchain }}-toolchain/workspace/repo
+          mv *.c *.h Makefile union-${{ matrix.toolchain }}-toolchain/workspace/repo
 
       - name: Pull the toolchain
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,16 @@ jobs:
           name: ${{ steps.binary.outputs.filename }}
           path: ${{ steps.binary.outputs.filename }}
 
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run unit tests
+        run: make test
+
   macos:
     name: macos
     runs-on: ${{ matrix.os }}
@@ -151,7 +161,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-24.04-arm
-    needs: [ci, macos]
+    needs: [ci, unit-tests, macos]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ minui
 /lib
 /platform
 minui-list-*
+/tmp/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ ifeq ($(PLATFORM),macos)
   -include platforms/macos/platform/makefile.env
 else
   ifeq (,$(CROSS_COMPILE))
-    $(error missing CROSS_COMPILE for this toolchain)
+    # the host-only targets below do not cross-compile, so they don't need a toolchain
+    ifeq (,$(filter test clean,$(MAKECMDGOALS)))
+      $(error missing CROSS_COMPILE for this toolchain)
+    endif
   endif
   CC = $(CROSS_COMPILE)gcc
   PREFIX = $(CURRENT_WORKING_DIR)/platform/$(PLATFORM)
@@ -44,13 +47,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_nav.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_nav.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
   ifneq (,$(filter $(PLATFORM),tg5050 h700))
@@ -92,6 +95,13 @@ endif
 
 clean:
 	rm -rf $(PRODUCT)-$(PLATFORM)
+
+# Build and run the pure-C unit tests with the host compiler (no SDL required)
+TEST_CC ?= cc
+test:
+	mkdir -p tmp
+	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_nav_test.c list_nav.c -o tmp/list_nav_test
+	./tmp/list_nav_test
 
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ minui-list --file list.json --selected 2
 # enable alphabetical scrolling with L1/R1 buttons
 # items will be sorted alphabetically automatically
 # L1 jumps to the previous letter group, R1 jumps to the next
+# both wrap around at the ends of the list
 minui-list --file list.json --alphabetic-scroll
 ```
 
@@ -227,7 +228,7 @@ A list of objects set at a particular key. May or may not be formatted. Comments
 Top-level properties (on the root object, not on individual items):
 
 - selected: (optional, type: `integer`, default: `0`) the index of the initially selected item. Can be overridden by the `--selected` CLI flag.
-- alphabetic_scroll: (optional, type: `boolean`, default: `false`) enables L1/R1 alphabetical scrolling. When enabled, items are automatically sorted alphabetically and L1/R1 buttons jump between letter groups. Headers and unselectable items are skipped.
+- alphabetic_scroll: (optional, type: `boolean`, default: `false`) enables L1/R1 alphabetical scrolling. When enabled, items are automatically sorted alphabetically and L1/R1 buttons jump between letter groups, wrapping around at the ends of the list. Headers and unselectable items are skipped.
 
 Item properties:
 
@@ -308,6 +309,13 @@ bats tests/
 
 # or point at a specific binary
 MINUI_LIST_BIN=./minui-list-macos bats tests/
+```
+
+Navigation logic that does not depend on a display, such as the L1/R1 alphabetic letter-jump, is covered by pure C unit tests in `tests/list_nav_test.c`. They build with the host compiler and need no SDL or cross toolchain:
+
+```shell
+# build and run the C unit tests
+make test
 ```
 
 ## Screenshots

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -42,12 +42,17 @@ The following keyboard keys are mapped to controller buttons:
 | B | A |
 | X | W |
 | Y | Q |
+| L1 | E |
+| R1 | R |
 | Start | Enter |
 | Select | ' (apostrophe) |
 | Menu | Space |
 | Power | Backspace |
 
-The L1/L2/R1/R2/L3/R3 and Plus/Minus buttons are not mapped.
+L1 (E) and R1 (R) drive alphabetical scrolling when `--alphabetic-scroll` is enabled: R1 jumps
+to the next letter group and L1 to the previous one, wrapping around at the ends of the list.
+
+The L2/R2/L3/R3 and Plus/Minus buttons are not mapped.
 
 ## Quitting
 

--- a/list_nav.c
+++ b/list_nav.c
@@ -1,0 +1,122 @@
+#include "list_nav.h"
+
+#include <ctype.h>
+#include <stddef.h>
+
+// nav_skip reports whether an item should be ignored while navigating.
+static bool nav_skip(const struct ListNavItem *item)
+{
+    return item->is_header || item->unselectable;
+}
+
+// nav_letter returns the uppercased first letter of an item's name.
+static int nav_letter(const struct ListNavItem *item)
+{
+    if (item->name == NULL)
+        return 0;
+    return toupper((unsigned char)item->name[0]);
+}
+
+int ListNav_PrevLetterIndex(const struct ListNavItem *items, int item_count, int selected)
+{
+    if (items == NULL || item_count <= 0 || selected < 0 || selected >= item_count)
+        return selected;
+
+    int current_letter = nav_letter(&items[selected]);
+    int target = -1;
+
+    // search backwards for the first item with a different letter
+    for (int i = selected - 1; i >= 0; i--)
+    {
+        if (nav_skip(&items[i]))
+            continue;
+
+        int letter = nav_letter(&items[i]);
+        if (letter != current_letter)
+        {
+            // found a different letter - walk back to the first item of its group
+            target = i;
+            for (int j = i - 1; j >= 0; j--)
+            {
+                if (nav_skip(&items[j]))
+                    continue;
+                if (nav_letter(&items[j]) == letter)
+                    target = j;
+                else
+                    break;
+            }
+            break;
+        }
+    }
+
+    // wrap: jump to the last letter group from the end of the list
+    if (target == -1)
+    {
+        for (int i = item_count - 1; i >= 0; i--)
+        {
+            if (nav_skip(&items[i]))
+                continue;
+
+            int letter = nav_letter(&items[i]);
+            if (letter != current_letter)
+            {
+                target = i;
+                for (int j = i - 1; j >= 0; j--)
+                {
+                    if (nav_skip(&items[j]))
+                        continue;
+                    if (nav_letter(&items[j]) == letter)
+                        target = j;
+                    else
+                        break;
+                }
+                break;
+            }
+        }
+    }
+
+    return (target != -1) ? target : selected;
+}
+
+int ListNav_NextLetterIndex(const struct ListNavItem *items, int item_count, int selected)
+{
+    if (items == NULL || item_count <= 0 || selected < 0 || selected >= item_count)
+        return selected;
+
+    int current_letter = nav_letter(&items[selected]);
+    int target = -1;
+
+    // search forwards for the first item with a different letter; on a sorted
+    // list that item is already the first of the next letter group
+    for (int i = selected + 1; i < item_count; i++)
+    {
+        if (nav_skip(&items[i]))
+            continue;
+
+        int letter = nav_letter(&items[i]);
+        if (letter != current_letter)
+        {
+            target = i;
+            break;
+        }
+    }
+
+    // wrap: jump to the first letter group from the beginning of the list
+    if (target == -1)
+    {
+        for (int i = 0; i < item_count; i++)
+        {
+            if (nav_skip(&items[i]))
+                continue;
+
+            int letter = nav_letter(&items[i]);
+            if (letter != current_letter)
+            {
+                target = i;
+                break;
+            }
+        }
+    }
+
+    return (target != -1) ? target : selected;
+}

--- a/list_nav.h
+++ b/list_nav.h
@@ -1,0 +1,28 @@
+#ifndef LIST_NAV_H
+#define LIST_NAV_H
+
+#include <stdbool.h>
+
+// ListNavItem is a minimal, SDL-free view of a list item used for alphabetic
+// (letter-group) navigation. Only the first character of `name` is significant;
+// header and unselectable items are skipped while navigating.
+struct ListNavItem
+{
+    const char *name;
+    bool is_header;
+    bool unselectable;
+};
+
+// ListNav_PrevLetterIndex returns the index of the first item of the letter
+// group preceding the selected item's group, wrapping to the last letter group
+// at the start of the list. Returns `selected` unchanged when there is no other
+// letter group (or the input is empty/out of range).
+int ListNav_PrevLetterIndex(const struct ListNavItem *items, int item_count, int selected);
+
+// ListNav_NextLetterIndex returns the index of the first item of the letter
+// group following the selected item's group, wrapping to the first letter group
+// at the end of the list. Returns `selected` unchanged when there is no other
+// letter group (or the input is empty/out of range).
+int ListNav_NextLetterIndex(const struct ListNavItem *items, int item_count, int selected);
+
+#endif // LIST_NAV_H

--- a/minui-list.c
+++ b/minui-list.c
@@ -19,6 +19,8 @@
 #include "api.h"
 #include "utils.h"
 
+#include "list_nav.h"
+
 // Platform compatibility: tg5050 (NextUI) uses PWR_isOnline instead of PLAT_isOnline
 #ifdef PLATFORM_NEXTUI
 #define PLAT_isOnline PWR_isOnline
@@ -1073,6 +1075,34 @@ void ListState_InitView(struct ListState *state, int max_row_count)
     }
 }
 
+// alphabetic_jump_target builds an SDL-free navigation view of the list and
+// returns the index to jump to for an alphabetic (L1/R1) letter jump. `forward`
+// selects next-letter (true) or previous-letter (false). Returns the current
+// selection unchanged when there is nowhere to jump.
+static int alphabetic_jump_target(struct ListState *state, bool forward)
+{
+    if (state->item_count == 0)
+        return state->selected;
+
+    struct ListNavItem *nav = malloc(state->item_count * sizeof(*nav));
+    if (nav == NULL)
+        return state->selected;
+
+    for (size_t i = 0; i < state->item_count; i++)
+    {
+        nav[i].name = state->items[i].name;
+        nav[i].is_header = state->items[i].features.is_header;
+        nav[i].unselectable = state->items[i].features.unselectable;
+    }
+
+    int target = forward
+                     ? ListNav_NextLetterIndex(nav, (int)state->item_count, state->selected)
+                     : ListNav_PrevLetterIndex(nav, (int)state->item_count, state->selected);
+
+    free(nav);
+    return target;
+}
+
 // handle_input interprets input events and mutates app state
 void handle_input(struct AppState *state)
 {
@@ -1413,133 +1443,26 @@ void handle_input(struct AppState *state)
     }
     else if (state->alphabetic_scroll && PAD_justRepeated(BTN_L1))
     {
-        if (state->list_state->item_count > 0)
+        // jump to the previous letter group; recompute the window so the new
+        // selection is framed correctly, including on wrap-around to the end
+        int target = alphabetic_jump_target(state->list_state, false);
+        if (target != state->list_state->selected)
         {
-            char current_letter = toupper((unsigned char)state->list_state->items[state->list_state->selected].name[0]);
-            int target_index = -1;
-
-            // Search backwards for first item with different letter
-            for (int i = state->list_state->selected - 1; i >= 0; i--)
-            {
-                if (state->list_state->items[i].features.is_header ||
-                    state->list_state->items[i].features.unselectable)
-                    continue;
-
-                char item_letter = toupper((unsigned char)state->list_state->items[i].name[0]);
-                if (item_letter != current_letter)
-                {
-                    // Found different letter - now find FIRST item with this letter
-                    target_index = i;
-                    for (int j = i - 1; j >= 0; j--)
-                    {
-                        if (state->list_state->items[j].features.is_header ||
-                            state->list_state->items[j].features.unselectable)
-                            continue;
-                        if (toupper((unsigned char)state->list_state->items[j].name[0]) == item_letter)
-                            target_index = j;
-                        else
-                            break;
-                    }
-                    break;
-                }
-            }
-
-            // Wrap: find last different letter from end
-            if (target_index == -1)
-            {
-                for (int i = state->list_state->item_count - 1; i >= 0; i--)
-                {
-                    if (state->list_state->items[i].features.is_header ||
-                        state->list_state->items[i].features.unselectable)
-                        continue;
-
-                    char item_letter = toupper((unsigned char)state->list_state->items[i].name[0]);
-                    if (item_letter != current_letter)
-                    {
-                        target_index = i;
-                        for (int j = i - 1; j >= 0; j--)
-                        {
-                            if (state->list_state->items[j].features.is_header ||
-                                state->list_state->items[j].features.unselectable)
-                                continue;
-                            if (toupper((unsigned char)state->list_state->items[j].name[0]) == item_letter)
-                                target_index = j;
-                            else
-                                break;
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (target_index != -1 && target_index != state->list_state->selected)
-            {
-                state->list_state->selected = target_index;
-                // Update visible window
-                if (state->list_state->selected < state->list_state->first_visible)
-                {
-                    state->list_state->first_visible = state->list_state->selected;
-                    state->list_state->last_visible = state->list_state->first_visible + max_row_count;
-                    if (state->list_state->last_visible > (int)state->list_state->item_count)
-                        state->list_state->last_visible = state->list_state->item_count;
-                }
-                state->redraw = 1;
-            }
+            state->list_state->selected = target;
+            ListState_InitView(state->list_state, max_row_count);
+            state->redraw = 1;
         }
     }
     else if (state->alphabetic_scroll && PAD_justRepeated(BTN_R1))
     {
-        if (state->list_state->item_count > 0)
+        // jump to the next letter group; recompute the window so the new
+        // selection is framed correctly, including on wrap-around to the start
+        int target = alphabetic_jump_target(state->list_state, true);
+        if (target != state->list_state->selected)
         {
-            char current_letter = toupper((unsigned char)state->list_state->items[state->list_state->selected].name[0]);
-            int target_index = -1;
-
-            // Search forwards for first item with different letter
-            for (int i = state->list_state->selected + 1; i < (int)state->list_state->item_count; i++)
-            {
-                if (state->list_state->items[i].features.is_header ||
-                    state->list_state->items[i].features.unselectable)
-                    continue;
-
-                char item_letter = toupper((unsigned char)state->list_state->items[i].name[0]);
-                if (item_letter != current_letter)
-                {
-                    target_index = i;
-                    break;
-                }
-            }
-
-            // Wrap: find first different letter from beginning
-            if (target_index == -1)
-            {
-                for (int i = 0; i < (int)state->list_state->item_count; i++)
-                {
-                    if (state->list_state->items[i].features.is_header ||
-                        state->list_state->items[i].features.unselectable)
-                        continue;
-
-                    char item_letter = toupper((unsigned char)state->list_state->items[i].name[0]);
-                    if (item_letter != current_letter)
-                    {
-                        target_index = i;
-                        break;
-                    }
-                }
-            }
-
-            if (target_index != -1 && target_index != state->list_state->selected)
-            {
-                state->list_state->selected = target_index;
-                // Update visible window
-                if (state->list_state->selected >= state->list_state->last_visible)
-                {
-                    state->list_state->last_visible = state->list_state->selected + 1;
-                    state->list_state->first_visible = state->list_state->last_visible - max_row_count;
-                    if (state->list_state->first_visible < 0)
-                        state->list_state->first_visible = 0;
-                }
-                state->redraw = 1;
-            }
+            state->list_state->selected = target;
+            ListState_InitView(state->list_state, max_row_count);
+            state->redraw = 1;
         }
     }
 }

--- a/tests/list_nav_test.c
+++ b/tests/list_nav_test.c
@@ -1,0 +1,139 @@
+// Unit tests for the pure alphabetic (L1/R1) letter-jump navigation helpers.
+// These have no SDL/display dependencies, so they run headless with the host
+// compiler via `make test`.
+
+#include "list_nav.h"
+
+#include <stdio.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected, msg)                                         \
+    do                                                                          \
+    {                                                                           \
+        checks++;                                                               \
+        int _a = (actual);                                                      \
+        int _e = (expected);                                                    \
+        if (_a != _e)                                                           \
+        {                                                                       \
+            failures++;                                                         \
+            fprintf(stderr, "FAIL: %s (expected %d, got %d)\n", (msg), _e, _a); \
+        }                                                                       \
+    } while (0)
+
+// convenience constructors keep the test bodies readable
+#define ITEM(n) {.name = (n), .is_header = false, .unselectable = false}
+#define HEADER(n) {.name = (n), .is_header = true, .unselectable = false}
+#define UNSEL(n) {.name = (n), .is_header = false, .unselectable = true}
+
+static void test_next_basic(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Avocado"), ITEM("Banana"), ITEM("Cherry")};
+    int n = 4;
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 0), 2, "next: A->B from first A");
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 1), 2, "next: A->B from second A");
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 2), 3, "next: B->C");
+}
+
+static void test_next_lands_on_first_of_group(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Banana"), ITEM("Berry"), ITEM("Cherry")};
+    int n = 4;
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 0), 1, "next: lands on first B (Banana)");
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 1), 3, "next: B->C skips second B");
+}
+
+static void test_prev_basic(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Avocado"), ITEM("Banana"), ITEM("Cherry")};
+    int n = 4;
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 3), 2, "prev: C->B (first B)");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 2), 0, "prev: B->A (first A)");
+}
+
+static void test_prev_lands_on_first_of_group(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Ant"), ITEM("Banana"), ITEM("Cherry")};
+    int n = 4;
+    // from Cherry, previous group is B, whose first item is index 2
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 3), 2, "prev: C->first B");
+    // from Banana, previous group is A, whose first item is index 0
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 2), 0, "prev: B->first A");
+}
+
+static void test_wrap(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Avocado"), ITEM("Banana"), ITEM("Cherry")};
+    int n = 4;
+    // next past the last letter wraps to the first group
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 3), 0, "next wrap: C->A");
+    // prev before the first letter wraps to the last group (its first item)
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 0), 3, "prev wrap: A->C");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 1), 3, "prev wrap: second A -> C");
+}
+
+static void test_single_letter_no_move(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Ant"), ITEM("Axe")};
+    int n = 3;
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 0), 0, "next: single letter stays put");
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 1), 1, "next: single letter stays put (mid)");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 2), 2, "prev: single letter stays put");
+}
+
+static void test_case_insensitive(void)
+{
+    struct ListNavItem items[] = {ITEM("apple"), ITEM("Banana")};
+    int n = 2;
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 0), 1, "next: lowercase a -> B");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 1), 0, "prev: B -> lowercase a");
+}
+
+static void test_skips_headers_and_unselectable(void)
+{
+    struct ListNavItem items[] = {HEADER("Fruits"), ITEM("Apple"), ITEM("Avocado"), ITEM("Banana")};
+    int n = 4;
+    CHECK_EQ(ListNav_NextLetterIndex(items, n, 1), 3, "next: A->B skipping header");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 3), 1, "prev: B->first selectable A (header skipped)");
+    // prev from the first A group wraps to B; the header is never selected
+    CHECK_EQ(ListNav_PrevLetterIndex(items, n, 1), 3, "prev wrap: A->B, header never targeted");
+
+    struct ListNavItem unsel[] = {UNSEL("Apple"), ITEM("Avocado"), ITEM("Banana")};
+    CHECK_EQ(ListNav_PrevLetterIndex(unsel, 3, 2), 1, "prev: B->first selectable A (unselectable skipped)");
+}
+
+static void test_edge_inputs(void)
+{
+    struct ListNavItem items[] = {ITEM("Apple"), ITEM("Banana")};
+    // empty list returns the selection unchanged
+    CHECK_EQ(ListNav_NextLetterIndex(items, 0, 0), 0, "next: empty list no-op");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, 0, 5), 5, "prev: empty list returns selected");
+    // NULL items returns the selection unchanged
+    CHECK_EQ(ListNav_NextLetterIndex(NULL, 3, 1), 1, "next: NULL items no-op");
+    // out-of-range selection returns unchanged
+    CHECK_EQ(ListNav_NextLetterIndex(items, 2, 9), 9, "next: out-of-range selected no-op");
+    CHECK_EQ(ListNav_PrevLetterIndex(items, 2, -1), -1, "prev: negative selected no-op");
+}
+
+int main(void)
+{
+    test_next_basic();
+    test_next_lands_on_first_of_group();
+    test_prev_basic();
+    test_prev_lands_on_first_of_group();
+    test_wrap();
+    test_single_letter_no_move();
+    test_case_insensitive();
+    test_skips_headers_and_unselectable();
+    test_edge_inputs();
+
+    if (failures == 0)
+    {
+        printf("ok - all %d checks passed\n", checks);
+        return 0;
+    }
+
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -63,16 +63,6 @@ setup() {
     [[ "$output" != *"unrecognized option"* ]]
 }
 
-@test "alphabetic_scroll JSON property is accepted" {
-    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-scroll.XXXXXX")"
-    printf '{"alphabetic_scroll": true, "items": []}' > "$JSONFILE"
-    run "$BIN" --file "$JSONFILE" --format json --item-key items
-    [ "$status" -eq 1 ]
-    # parses past the JSON schema (the key is accepted) and reaches item validation
-    [[ "$output" == *"No selectable items found"* ]]
-    [[ "$output" != *"Failed to parse JSON"* ]]
-}
-
 # surviving validation
 
 @test "invalid format is rejected" {

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -47,6 +47,32 @@ setup() {
     [[ "$output" != *"cannot be assigned to more than one button"* ]]
 }
 
+# issue 69 - L1/R1 alphabetic scroll navigation
+
+@test "--alphabetic-scroll flag is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --alphabetic-scroll
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"unrecognized option"* ]]
+}
+
+@test "-S short flag is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml -S
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"unrecognized option"* ]]
+}
+
+@test "alphabetic_scroll JSON property is accepted" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-scroll.XXXXXX")"
+    printf '{"alphabetic_scroll": true, "items": []}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json --item-key items
+    [ "$status" -eq 1 ]
+    # parses past the JSON schema (the key is accepted) and reaches item validation
+    [[ "$output" == *"No selectable items found"* ]]
+    [[ "$output" != *"Failed to parse JSON"* ]]
+}
+
 # surviving validation
 
 @test "invalid format is rejected" {


### PR DESCRIPTION
Issue #69 requested MinUI-style L1/R1 letter scrolling, which is enabled with `--alphabetic-scroll`. The L1/R1 letter-jump only reframed the visible window in the direction it normally travels, so wrapping past either end of a list longer than one screen left the selection off-screen with no scroll. The jump now reframes the window around the new selection in every case, including wrap-around, matching how the list is framed on startup.

The letter-jump behavior is now covered by headless C unit tests, and the macOS documentation records the L1/R1 to E/R key bindings that make the feature usable in that build.

Closes #69