### PR TITLE
fix: validate JSON item shapes to prevent segfault

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ item 3
 
 ##### Array
 
-A json array. May or may not be formatted.
+A json array of strings. May or may not be formatted.
 
 ```json
 [
@@ -203,6 +203,11 @@ A json array. May or may not be formatted.
   "item 3"
 ]
 ```
+
+Every element must be a non-empty string. To supply object items (with names,
+options, or features), use the object form below with `--item-key`. Passing an
+array of objects, an empty string, or any non-string element fails with a
+validation error rather than rendering.
 
 ##### Object
 
@@ -281,6 +286,11 @@ Item example:
 > If items are specified in json format, the item list _must_ have at
 > least one selectable, non-header item.
 > The `minui-list` binary will exit with an error if that is not the case.
+
+> [!WARNING]
+> Every item under `--item-key` must be an object with a non-empty `name`.
+> A non-object element, or an item without a name, fails with a validation
+> error rather than rendering.
 
 ### Exit Codes
 

--- a/minui-list.c
+++ b/minui-list.c
@@ -540,6 +540,56 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
 
     size_t item_count = json_array_get_count(items_array);
 
+    // validate each element's shape before allocating or rendering.
+    // invalid input (objects in a top-level array, or non-object/nameless
+    // items under an item key) would otherwise yield empty item names that
+    // crash the renderer, so fail here the way other malformed input does.
+    for (size_t i = 0; i < item_count; i++)
+    {
+        JSON_Value *element = json_array_get_value(items_array, i);
+        char error_message[256];
+        error_message[0] = '\0';
+
+        if (strlen(item_key) == 0)
+        {
+            if (json_value_get_type(element) != JSONString)
+            {
+                snprintf(error_message, sizeof(error_message), "Array item %zu is not a string; use --item-key for object lists", i);
+            }
+            else
+            {
+                const char *element_name = json_value_get_string(element);
+                if (element_name == NULL || element_name[0] == '\0')
+                {
+                    snprintf(error_message, sizeof(error_message), "Array item %zu has an empty name", i);
+                }
+            }
+        }
+        else
+        {
+            if (json_value_get_type(element) != JSONObject)
+            {
+                snprintf(error_message, sizeof(error_message), "Item %zu under key '%s' is not an object", i, item_key);
+            }
+            else
+            {
+                const char *element_name = json_object_get_string(json_value_get_object(element), "name");
+                if (element_name == NULL || element_name[0] == '\0')
+                {
+                    snprintf(error_message, sizeof(error_message), "Item %zu under key '%s' is missing a name", i, item_key);
+                }
+            }
+        }
+
+        if (error_message[0] != '\0')
+        {
+            log_error(error_message);
+            json_value_free(root_value);
+            free(state);
+            return NULL;
+        }
+    }
+
     state->items = malloc(sizeof(struct ListItem) * item_count);
     state->has_options = false;
 

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -88,3 +88,44 @@ setup() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"No input provided"* ]]
 }
+
+# issue 123 - segfault on JSON array of objects without --item-key
+#
+# invalid JSON item shapes used to reach the renderer with empty names and
+# crash (EXC_BAD_ACCESS, exit 139). They must now fail gracefully instead.
+
+@test "top-level array of objects is rejected (no segfault)" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '[{"name":"Apple"},{"name":"Banana"}]' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"is not a string"* ]]
+}
+
+@test "empty string in a top-level array is rejected" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '[""]' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"empty name"* ]]
+}
+
+@test "strings under --item-key are rejected (no segfault)" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":["Apple","Banana"]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json --item-key items
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"is not an object"* ]]
+}
+
+@test "nameless object under --item-key is rejected" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":[{}]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json --item-key items
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"missing a name"* ]]
+}


### PR DESCRIPTION
A top-level JSON array of objects, or non-object and nameless items under `--item-key`, previously crashed with a segfault because the items reached rendering with empty names. `ListState_New` now validates each element and exits with a clear error instead, matching how other malformed input is handled.

Fixes #123.
