### PR TITLE
fix: parse JSON object form without requiring --item-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ This tool is designed to be used as part of a larger minui app.
 # ["item-1", "item-2", "item-3"]
 minui-list --file list.json
 
-# you can also read from a JSON file that containing an object with an array of objects at a specific key
+# you can also read from a JSON file that contains an object with an array of objects
 # note that the objects must have a "name" key, which will be used as the item name
 # {"items": [{"name": "item-1"}, {"name": "item-2"}, {"name": "item-3"}]}
-minui-list --file list.json --item-key "items"
+minui-list --file list.json
+
+# --item-key defaults to "items", so it only needs to be passed when the array
+# lives under a differently-named key
+# {"choices": [{"name": "item-1"}, {"name": "item-2"}, {"name": "item-3"}]}
+minui-list --file list.json --item-key "choices"
 
 # you can also read from newline-delimited strings by specifying the --format flag
 # the default format is "json", but you can also specify "text"
@@ -212,6 +217,9 @@ validation error rather than rendering.
 ##### Object
 
 A list of objects set at a particular key. May or may not be formatted. Comments are allowed.
+
+The key defaults to `items`, so the object form below works without any extra flags.
+Pass `--item-key <key>` only when the array lives under a differently-named key.
 
 ```json
 {

--- a/minui-list.c
+++ b/minui-list.c
@@ -528,14 +528,20 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
         }
     }
 
+    // decide array form vs object form from the root JSON type, not from whether
+    // --item-key was supplied. a root object is the object form (items live under
+    // item_key, "items" by default); a root array is the array-of-strings form and
+    // ignores item_key.
+    bool use_object_form = json_value_get_type(root_value) == JSONObject;
+
     JSON_Array *items_array;
-    if (strlen(item_key) == 0)
+    if (use_object_form)
     {
-        items_array = json_value_get_array(root_value);
+        items_array = json_value_get_array(json_object_get_value(json_value_get_object(root_value), item_key));
     }
     else
     {
-        items_array = json_value_get_array(json_object_get_value(json_value_get_object(root_value), item_key));
+        items_array = json_value_get_array(root_value);
     }
 
     size_t item_count = json_array_get_count(items_array);
@@ -550,7 +556,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
         char error_message[256];
         error_message[0] = '\0';
 
-        if (strlen(item_key) == 0)
+        if (!use_object_form)
         {
             if (json_value_get_type(element) != JSONString)
             {
@@ -593,7 +599,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
     state->items = malloc(sizeof(struct ListItem) * item_count);
     state->has_options = false;
 
-    if (strlen(item_key) == 0)
+    if (!use_object_form)
     {
         for (size_t i = 0; i < item_count; i++)
         {
@@ -1058,7 +1064,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
     state->item_count = item_count;
 
     // read the requested initial selection from JSON (if any)
-    if (strlen(item_key) > 0)
+    if (use_object_form)
     {
         JSON_Object *root_obj = json_value_get_object(root_value);
         if (root_obj && json_object_has_value(root_obj, "selected"))
@@ -2722,7 +2728,7 @@ int main(int argc, char *argv[])
     char default_confirm_text[1024] = "SELECT";
     char default_file[1024] = "";
     char default_format[1024] = "json";
-    char default_item_key[1024] = "";
+    char default_item_key[1024] = "items";
     char default_write_value[1024] = "selected";
     char default_title[1024] = "";
     char default_title_alignment[1024] = "left";

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -129,3 +129,30 @@ setup() {
     [ "$status" -ne 139 ]
     [[ "$output" == *"missing a name"* ]]
 }
+
+# issue 124 - JSON object form should work without --item-key
+#
+# a root object is now parsed as the object form using the default "items" key,
+# so it no longer needs --item-key. these inputs fail object-form validation
+# (proving the object path is taken); before the fix they yielded the generic
+# "No selectable items found".
+
+@test "object form uses the default items key without --item-key" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":[{}]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"missing a name"* ]]
+    [[ "$output" != *"No selectable items found"* ]]
+}
+
+@test "strings under the default items key are rejected without --item-key" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":["Apple","Banana"]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"is not an object"* ]]
+    [[ "$output" != *"No selectable items found"* ]]
+}


### PR DESCRIPTION
Fixes #124.

The JSON object form documented in the README failed with `No selectable items found` unless `--item-key items` was passed, even though the `--item-key` help text claims a default of `items`. The parser chose between the array form and the object form based on whether `--item-key` was supplied rather than on the shape of the input, so `{"items": [...]}` was misrouted and produced no items.

A root object is now treated as the object form and reads its items under `--item-key`, which defaults to `items`, while a root array remains the array-of-strings form. The documented object example now works without any extra flags, a differently-named key is still selectable with `--item-key`, and a top-level `selected` is honored for the object form whether or not `--item-key` was passed.
