### PR TITLE
feat: autoscroll over-long selected item text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c list_nav.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c list_nav.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
   ifneq (,$(filter $(PLATFORM),tg5050 h700))
@@ -102,6 +102,8 @@ test:
 	mkdir -p tmp
 	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_nav_test.c list_nav.c -o tmp/list_nav_test
 	./tmp/list_nav_test
+	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_scroll_test.c list_scroll.c -o tmp/list_scroll_test
+	./tmp/list_scroll_test
 
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui

--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ minui-list --file list.json --selected 2
 # L1 jumps to the previous letter group, R1 jumps to the next
 # both wrap around at the ends of the list
 minui-list --file list.json --alphabetic-scroll
+
+# autoscroll the selected item's name when it is too long to fit
+# by default the name is truncated with an ellipsis ("...")
+# the supported values are "false" (default), "wrap", and "pong"
+# "wrap" is a continuous looping marquee; "pong" scrolls to the end,
+# pauses, then scrolls back to the start
+# only the currently selected item scrolls; other long items keep the ellipsis
+minui-list --file list.json --scroll-method wrap
+
+# the scroll method can also be set via the top-level "scroll_method" JSON
+# property; when present in the JSON it takes precedence over the flag
+minui-list --file list.json --scroll-method pong
 ```
 
 To create a list of items from newline-delimited strings, you can use jq:
@@ -242,6 +254,7 @@ Top-level properties (on the root object, not on individual items):
 
 - selected: (optional, type: `integer`, default: `0`) the index of the initially selected item. Can be overridden by the `--selected` CLI flag.
 - alphabetic_scroll: (optional, type: `boolean`, default: `false`) enables L1/R1 alphabetical scrolling. When enabled, items are automatically sorted alphabetically and L1/R1 buttons jump between letter groups, wrapping around at the ends of the list. Headers and unselectable items are skipped.
+- scroll_method: (optional, type: `string`, default: `false`) how to autoscroll the selected item's name when it is too long to fit. One of `false` (truncate with an ellipsis), `wrap` (continuous looping marquee), or `pong` (scroll to the end, pause, then scroll back). Only the currently selected, selectable, non-color item scrolls; other long items keep the ellipsis, and a scrolling item is always rendered left-aligned. When present, this property takes precedence over the `--scroll-method` CLI flag.
 
 Item properties:
 

--- a/list_scroll.c
+++ b/list_scroll.c
@@ -1,0 +1,84 @@
+#include "list_scroll.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+enum ScrollMethod ScrollMethod_Parse(const char *s)
+{
+    if (s == NULL)
+        return SCROLL_NONE;
+    if (strcmp(s, "wrap") == 0)
+        return SCROLL_WRAP;
+    if (strcmp(s, "pong") == 0)
+        return SCROLL_PONG;
+    // "false", "", and anything unrecognized disable scrolling
+    return SCROLL_NONE;
+}
+
+// clamp_nonneg returns v, or 0 when v is negative.
+static int clamp_nonneg(int v)
+{
+    return v < 0 ? 0 : v;
+}
+
+int TextScroll_Offset(enum ScrollMethod method, const struct ScrollConfig *cfg,
+                      unsigned int elapsed_ms, int text_width, int viewport_width)
+{
+    if (method == SCROLL_NONE || cfg == NULL)
+        return 0;
+    if (cfg->speed_px_per_sec <= 0 || text_width <= 0 || viewport_width <= 0)
+        return 0;
+
+    int overflow = text_width - viewport_width;
+    if (overflow <= 0 || overflow <= cfg->overflow_threshold_px)
+        return 0;
+
+    uint64_t speed = (uint64_t)cfg->speed_px_per_sec;
+    unsigned int start_pause = (unsigned int)clamp_nonneg(cfg->start_pause_ms);
+
+    if (method == SCROLL_WRAP)
+    {
+        // continuous loop: an initial pause, then slide left forever, wrapping
+        // after the text plus a trailing gap. two copies (drawn by the caller)
+        // make the wrap seamless.
+        int period = text_width + clamp_nonneg(cfg->gap_px);
+        if (period <= 0)
+            return 0;
+
+        uint64_t traveled = 0;
+        if (elapsed_ms > start_pause)
+            traveled = speed * (uint64_t)(elapsed_ms - start_pause) / 1000u;
+
+        return (int)(traveled % (uint64_t)period);
+    }
+
+    // SCROLL_PONG: pause, ramp to the end, pause, ramp back to the start, repeat.
+    unsigned int end_pause = (unsigned int)clamp_nonneg(cfg->end_pause_ms);
+    uint64_t travel_ms = (uint64_t)overflow * 1000u / speed;
+
+    uint64_t cycle = (uint64_t)start_pause + travel_ms + (uint64_t)end_pause + travel_ms;
+    if (cycle == 0)
+        return 0;
+
+    uint64_t t = (uint64_t)elapsed_ms % cycle;
+    uint64_t p1_end = start_pause;             // hold at start
+    uint64_t p2_end = p1_end + travel_ms;      // ramp toward the end
+    uint64_t p3_end = p2_end + end_pause;      // hold at the end
+
+    if (t < p1_end)
+        return 0;
+    if (t < p2_end)
+    {
+        uint64_t off = speed * (t - p1_end) / 1000u;
+        return off > (uint64_t)overflow ? overflow : (int)off;
+    }
+    if (t < p3_end)
+        return overflow;
+
+    // ramp back toward the start
+    uint64_t off = speed * (t - p3_end) / 1000u;
+    if (off > (uint64_t)overflow)
+        off = (uint64_t)overflow;
+    return overflow - (int)off;
+}

--- a/list_scroll.h
+++ b/list_scroll.h
@@ -1,0 +1,57 @@
+#ifndef LIST_SCROLL_H
+#define LIST_SCROLL_H
+
+// list_scroll provides the SDL-free math behind autoscrolling (marquee) list
+// text. It only computes a horizontal pixel offset from elapsed time; the
+// caller measures text, sets clip rects, and blits. Keeping it display-free
+// means it can be unit tested with the host compiler (see tests/list_scroll_test.c).
+
+// ScrollMethod selects how over-long text is animated.
+// SCROLL_NONE keeps the existing ellipsis truncation.
+// SCROLL_WRAP is a continuous looping marquee (text slides left, then repeats
+// after a gap). SCROLL_PONG bounces left to reveal the end, then back again.
+enum ScrollMethod
+{
+    SCROLL_NONE = 0,
+    SCROLL_WRAP,
+    SCROLL_PONG,
+};
+
+// ScrollConfig tunes the animation. All pixel values are expected to already be
+// display-scaled by the caller (e.g. via SCALE1), so this module stays unit-free.
+struct ScrollConfig
+{
+    // horizontal speed in pixels per second
+    int speed_px_per_sec;
+    // time to hold before scrolling begins (both methods)
+    int start_pause_ms;
+    // pong: time to hold at the far (fully-revealed) end
+    int end_pause_ms;
+    // wrap: gap between the end of the text and its repeated copy
+    int gap_px;
+    // do not scroll when the overflow is at or below this many pixels
+    int overflow_threshold_px;
+};
+
+// ScrollMethod_Parse maps a string to a ScrollMethod. "wrap" and "pong" map to
+// their methods; "false", the empty string, NULL, and anything unrecognized map
+// to SCROLL_NONE so callers degrade gracefully.
+enum ScrollMethod ScrollMethod_Parse(const char *s);
+
+// TextScroll_Offset returns how many pixels to shift the text left for the
+// current frame. `elapsed_ms` is the time since the animation started (i.e.
+// since the row became selected). `text_width` is the full, untruncated text
+// width and `viewport_width` is the visible region.
+//
+// Returns 0 when there is nothing to scroll: method is SCROLL_NONE, the config
+// is missing/non-positive, or the overflow (text_width - viewport_width) is at
+// or below overflow_threshold_px.
+//
+// WRAP: the returned offset is in [0, text_width + gap_px); the caller draws the
+// text twice, at (x - offset) and (x - offset + text_width + gap_px).
+// PONG: the returned offset is in [0, text_width - viewport_width]; the caller
+// draws the text once at (x - offset).
+int TextScroll_Offset(enum ScrollMethod method, const struct ScrollConfig *cfg,
+                      unsigned int elapsed_ms, int text_width, int viewport_width);
+
+#endif // LIST_SCROLL_H

--- a/minui-list.c
+++ b/minui-list.c
@@ -20,6 +20,7 @@
 #include "utils.h"
 
 #include "list_nav.h"
+#include "list_scroll.h"
 
 // Platform compatibility: tg5050 (NextUI) uses PWR_isOnline instead of PLAT_isOnline
 #ifdef PLATFORM_NEXTUI
@@ -214,6 +215,16 @@ struct AppState
     bool disable_auto_sleep;
     // whether alphabetic scroll (L1/R1 letter jumping) is enabled
     bool alphabetic_scroll;
+    // how to autoscroll over-long selected item text ('false', 'wrap', 'pong')
+    char scroll_method[1024];
+    // timestamp (ms) when the current row's autoscroll animation started
+    uint32_t scroll_anim_start_ms;
+    // the selected index the autoscroll clock is tracking (-1 = none yet)
+    int scroll_anim_selected;
+    // the selected option index the autoscroll clock is tracking (-1 = none yet)
+    int scroll_anim_option;
+    // whether a row is currently autoscrolling (drives per-frame redraws)
+    bool scroll_active;
     // maximum number of visible list rows
     int max_row_count;
     // the button to display on the Enable button
@@ -525,6 +536,19 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
         if (json_object_get_boolean(root_object, "alphabetic_scroll") == 1)
         {
             app_state->alphabetic_scroll = true;
+        }
+    }
+
+    // Check for scroll_method in root JSON object. When present it takes
+    // precedence over the --scroll-method flag. An unrecognized value is not a
+    // hard error: ScrollMethod_Parse maps it to SCROLL_NONE at render time.
+    if (root_object != NULL && json_object_has_value(root_object, "scroll_method"))
+    {
+        const char *scroll_method = json_object_get_string(root_object, "scroll_method");
+        if (scroll_method != NULL)
+        {
+            strncpy(app_state->scroll_method, scroll_method, sizeof(app_state->scroll_method) - 1);
+            app_state->scroll_method[sizeof(app_state->scroll_method) - 1] = '\0';
         }
     }
 
@@ -1801,6 +1825,19 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
     bool current_item_is_enabled = false;
     bool current_item_is_header = false;
     int selected_row = state->list_state->selected - state->list_state->first_visible;
+
+    // autoscroll configuration for the selected row's over-long name; cleared
+    // each frame and re-armed below whenever a row is actually scrolling
+    enum ScrollMethod scroll_method = ScrollMethod_Parse(state->scroll_method);
+    struct ScrollConfig scroll_config = {
+        .speed_px_per_sec = SCALE1(40),
+        .start_pause_ms = 1000,
+        .end_pause_ms = 1000,
+        .gap_px = SCALE1(40),
+        .overflow_threshold_px = SCALE1(4),
+    };
+    state->scroll_active = false;
+
     for (int i = state->list_state->first_visible, j = 0; i < state->list_state->last_visible; i++, j++)
     {
         int available_width = (screen->w) - SCALE1(PADDING * 2);
@@ -1875,7 +1912,57 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
 
         char truncated_display_text[256];
         int text_width = GFX_truncateText(state->fonts.large, display_text, truncated_display_text, available_width, SCALE1(BUTTON_PADDING * 2));
+
+        // Decide whether this (selected) row should autoscroll its over-long
+        // name instead of showing the "..." ellipsis. Only the selected,
+        // selectable, non-hex row scrolls; every other row keeps the truncated
+        // text unchanged.
+        bool row_scrolls = false;
+        int scroll_offset = 0;
+        int scroll_full_width = 0;
+        int scroll_viewport = 0;
+        if (j == selected_row && scroll_method != SCROLL_NONE && !is_hex_color &&
+            !state->list_state->items[i].features.is_header &&
+            !state->list_state->items[i].features.unselectable)
+        {
+            TTF_SizeUTF8(state->fonts.large, display_text, &scroll_full_width, NULL);
+            scroll_viewport = available_width - SCALE1(BUTTON_PADDING * 2);
+
+            // keep the marquee clear of a right-aligned option value, if present
+            if (strcmp(display_selected_text, "") != 0)
+            {
+                int value_width = 0;
+                TTF_SizeUTF8(state->fonts.large, display_selected_text, &value_width, NULL);
+                int value_left = screen->w - value_width - SCALE1(PADDING + BUTTON_PADDING) - color_box_space;
+                int value_viewport = value_left - SCALE1(PADDING + BUTTON_PADDING) - SCALE1(PADDING);
+                if (value_viewport < scroll_viewport)
+                {
+                    scroll_viewport = value_viewport;
+                }
+            }
+
+            if (scroll_viewport > 0 && (scroll_full_width - scroll_viewport) > scroll_config.overflow_threshold_px)
+            {
+                // reset the animation clock when the selected row or its option changes
+                if (state->scroll_anim_selected != state->list_state->selected ||
+                    state->scroll_anim_option != state->list_state->items[i].selected)
+                {
+                    state->scroll_anim_selected = state->list_state->selected;
+                    state->scroll_anim_option = state->list_state->items[i].selected;
+                    state->scroll_anim_start_ms = SDL_GetTicks();
+                }
+                uint32_t scroll_elapsed = SDL_GetTicks() - state->scroll_anim_start_ms;
+                scroll_offset = TextScroll_Offset(scroll_method, &scroll_config, scroll_elapsed, scroll_full_width, scroll_viewport);
+                row_scrolls = true;
+            }
+        }
+
         int pill_width = MIN(available_width, text_width) + color_box_space;
+        if (row_scrolls)
+        {
+            // pin the pill to the full available width so the marquee frame is stable
+            pill_width = available_width + color_box_space;
+        }
 
         if (j == selected_row)
         {
@@ -1927,6 +2014,12 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
                 }
             }
 
+            // a scrolling marquee always renders left-origin, so pin its pill left
+            if (row_scrolls)
+            {
+                pill_x_pos = SCALE1(PADDING);
+            }
+
             if (strcmp(display_selected_text, "") != 0)
             {
                 GFX_blitPill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), screen->w - SCALE1(PADDING + BUTTON_MARGIN), SCALE1(PILL_SIZE)});
@@ -1936,7 +2029,16 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
         }
 
         SDL_Surface *text;
-        text = TTF_RenderUTF8_Blended(state->fonts.large, truncated_display_text, text_color);
+        if (row_scrolls)
+        {
+            // render the full, untruncated name for the marquee
+            text = TTF_RenderUTF8_Blended(state->fonts.large, display_text, text_color);
+        }
+        else
+        {
+            text = TTF_RenderUTF8_Blended(state->fonts.large, truncated_display_text, text_color);
+        }
+        int text_surface_width = text->w;
 
         // Calculate text position based on alignment
         int text_x_pos;
@@ -1974,31 +2076,62 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             }
         }
 
+        // a scrolling marquee always renders left-origin
+        if (row_scrolls)
+        {
+            text_x_pos = SCALE1(PADDING + BUTTON_PADDING);
+        }
+
+        int text_y_pos = SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding + 4);
         SDL_Rect pos = {
             text_x_pos,
-            SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding + 4),
+            text_y_pos,
             text->w,
             text->h};
 
-        // draw the text as a black shadow
-        if (should_draw_background_image && j != selected_row)
+        if (row_scrolls)
         {
-            // COLOR_BLACK
-            SDL_Surface *accent_text;
-            accent_text = TTF_RenderUTF8_Blended(state->fonts.large, truncated_display_text, COLOR_BLACK);
-            SDL_Rect accent_pos = {
-                shadow_x_pos,
-                SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding + 4 + 2),
-                accent_text->w,
-                accent_text->h};
-            SDL_BlitSurface(accent_text, NULL, screen, &accent_pos);
-            SDL_FreeSurface(accent_text);
+            // clip the marquee to the pill interior and blit the full text at the
+            // animated offset; wrap draws a second copy after a gap so the loop
+            // is seamless
+            int clip_y_pos = SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding);
+            SDL_Rect scroll_clip = {text_x_pos, clip_y_pos, scroll_viewport, SCALE1(PILL_SIZE)};
+            SDL_SetClipRect(screen, &scroll_clip);
+
+            SDL_Rect scroll_pos = {text_x_pos - scroll_offset, text_y_pos, text->w, text->h};
+            SDL_BlitSurface(text, NULL, screen, &scroll_pos);
+            if (scroll_method == SCROLL_WRAP)
+            {
+                SDL_Rect scroll_pos_2 = {text_x_pos - scroll_offset + scroll_full_width + scroll_config.gap_px, text_y_pos, text->w, text->h};
+                SDL_BlitSurface(text, NULL, screen, &scroll_pos_2);
+            }
+
+            SDL_SetClipRect(screen, NULL);
+            state->scroll_active = true;
+        }
+        else
+        {
+            // draw the text as a black shadow
+            if (should_draw_background_image && j != selected_row)
+            {
+                // COLOR_BLACK
+                SDL_Surface *accent_text;
+                accent_text = TTF_RenderUTF8_Blended(state->fonts.large, truncated_display_text, COLOR_BLACK);
+                SDL_Rect accent_pos = {
+                    shadow_x_pos,
+                    SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding + 4 + 2),
+                    accent_text->w,
+                    accent_text->h};
+                SDL_BlitSurface(accent_text, NULL, screen, &accent_pos);
+                SDL_FreeSurface(accent_text);
+            }
+
+            SDL_BlitSurface(text, NULL, screen, &pos);
         }
 
-        SDL_BlitSurface(text, NULL, screen, &pos);
         SDL_FreeSurface(text);
 
-        int initial_cube_x_pos = text_x_pos + text->w;
+        int initial_cube_x_pos = text_x_pos + text_surface_width;
 
         // draw the selected option text
         if (strcmp(display_selected_text, "") != 0)
@@ -2243,6 +2376,7 @@ void signal_handler(int signal)
 // - --title <title> (default: empty string)
 // - --title-alignment <alignment> (default: "left")
 // - --item-key <key> (default: "items")
+// - --scroll-method <method> (default: "false")
 // - --write-location <location> (default: "-")
 // - --write-value <value> (default: "selected")
 bool parse_arguments(struct AppState *state, int argc, char *argv[])
@@ -2266,6 +2400,7 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         {"item-key", required_argument, 0, 'K'},
         {"title", required_argument, 0, 't'},
         {"title-alignment", required_argument, 0, 'T'},
+        {"scroll-method", required_argument, 0, 'r'},
         {"write-location", required_argument, 0, 'w'},
         {"write-value", required_argument, 0, 'W'},
         {"selected", required_argument, 0, 's'},
@@ -2278,7 +2413,7 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
     char *font_path_default = NULL;
     char *font_path_large = NULL;
     char *font_path_medium = NULL;
-    while ((opt = getopt_long(argc, argv, "a:A:b:B:c:C:d:D:e:f:F:l:L:M:K:s:t:T:w:W:XUHS", long_options, NULL)) != -1)
+    while ((opt = getopt_long(argc, argv, "a:A:b:B:c:C:d:D:e:f:F:l:L:M:K:r:s:t:T:w:W:XUHS", long_options, NULL)) != -1)
     {
         switch (opt)
         {
@@ -2339,6 +2474,9 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         case 'T':
             strncpy(state->title_alignment, optarg, sizeof(state->title_alignment) - 1);
             break;
+        case 'r':
+            strncpy(state->scroll_method, optarg, sizeof(state->scroll_method) - 1);
+            break;
         case 'w':
             strncpy(state->write_location, optarg, sizeof(state->write_location) - 1);
             break;
@@ -2363,6 +2501,13 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
     if (strcmp(state->title_alignment, "left") != 0 && strcmp(state->title_alignment, "center") != 0 && strcmp(state->title_alignment, "right") != 0)
     {
         log_error("Invalid title alignment provided. Please provide a value of 'left', 'center', or 'right'.");
+        return false;
+    }
+
+    // validate scroll method
+    if (strcmp(state->scroll_method, "false") != 0 && strcmp(state->scroll_method, "wrap") != 0 && strcmp(state->scroll_method, "pong") != 0)
+    {
+        log_error("Invalid scroll method provided. Please provide a value of 'false', 'wrap', or 'pong'.");
         return false;
     }
 
@@ -2732,6 +2877,7 @@ int main(int argc, char *argv[])
     char default_write_value[1024] = "selected";
     char default_title[1024] = "";
     char default_title_alignment[1024] = "left";
+    char default_scroll_method[1024] = "false";
     char default_write_location[1024] = "-";
     struct AppState state = {
         .exit_code = ExitCodeSuccess,
@@ -2742,6 +2888,8 @@ int main(int argc, char *argv[])
         .always_show_confirm = false,
         .disable_auto_sleep = false,
         .initial_selected = -1,
+        .scroll_anim_selected = -1,
+        .scroll_anim_option = -1,
         .fonts = {
             .large = NULL,
             .medium = NULL,
@@ -2767,6 +2915,7 @@ int main(int argc, char *argv[])
     strncpy(state.write_value, default_write_value, sizeof(state.write_value) - 1);
     strncpy(state.title, default_title, sizeof(state.title) - 1);
     strncpy(state.title_alignment, default_title_alignment, sizeof(state.title_alignment) - 1);
+    strncpy(state.scroll_method, default_scroll_method, sizeof(state.scroll_method) - 1);
     strncpy(state.write_location, default_write_location, sizeof(state.write_location) - 1);
 
     // parse the arguments
@@ -2899,6 +3048,14 @@ int main(int argc, char *argv[])
 
         // force a redraw if the power state changed
         if (power_redraw)
+        {
+            state.redraw = 1;
+        }
+
+        // keep redrawing while a row is autoscrolling so the marquee animates.
+        // this is self-sustaining: draw_screen re-arms scroll_active each frame
+        // it draws a scrolling row, and clears it once nothing is scrolling.
+        if (state.scroll_active)
         {
             state.redraw = 1;
         }

--- a/tests/list_scroll_test.c
+++ b/tests/list_scroll_test.c
@@ -1,0 +1,124 @@
+// Unit tests for the pure text-autoscroll (marquee) offset helpers. These have
+// no SDL/display dependencies, so they run headless with the host compiler via
+// `make test`.
+
+#include "list_scroll.h"
+
+#include <stdio.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected, msg)                                         \
+    do                                                                          \
+    {                                                                           \
+        checks++;                                                               \
+        int _a = (actual);                                                      \
+        int _e = (expected);                                                    \
+        if (_a != _e)                                                           \
+        {                                                                       \
+            failures++;                                                         \
+            fprintf(stderr, "FAIL: %s (expected %d, got %d)\n", (msg), _e, _a); \
+        }                                                                       \
+    } while (0)
+
+// 100 px/sec keeps the arithmetic easy: 1px per 10ms, 100px per 1000ms.
+static const struct ScrollConfig CFG = {
+    .speed_px_per_sec = 100,
+    .start_pause_ms = 1000,
+    .end_pause_ms = 1000,
+    .gap_px = 40,
+    .overflow_threshold_px = 4,
+};
+
+static void test_parse(void)
+{
+    CHECK_EQ(ScrollMethod_Parse("wrap"), SCROLL_WRAP, "parse: wrap");
+    CHECK_EQ(ScrollMethod_Parse("pong"), SCROLL_PONG, "parse: pong");
+    CHECK_EQ(ScrollMethod_Parse("false"), SCROLL_NONE, "parse: false");
+    CHECK_EQ(ScrollMethod_Parse(""), SCROLL_NONE, "parse: empty");
+    CHECK_EQ(ScrollMethod_Parse(NULL), SCROLL_NONE, "parse: NULL");
+    CHECK_EQ(ScrollMethod_Parse("bounce"), SCROLL_NONE, "parse: unknown");
+    CHECK_EQ(ScrollMethod_Parse("WRAP"), SCROLL_NONE, "parse: case-sensitive");
+}
+
+static void test_guards(void)
+{
+    // NONE never scrolls
+    CHECK_EQ(TextScroll_Offset(SCROLL_NONE, &CFG, 5000, 200, 100), 0, "none: no scroll");
+    // NULL config
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, NULL, 5000, 200, 100), 0, "wrap: NULL cfg");
+    // non-positive dimensions
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 5000, 0, 100), 0, "wrap: zero text width");
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 5000, 200, 0), 0, "wrap: zero viewport");
+    // text fits (no overflow)
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 5000, 100, 100), 0, "wrap: viewport == text");
+    // overflow at/below threshold does not scroll (overflow 2 and 4, threshold 4)
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 5000, 102, 100), 0, "wrap: below threshold");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 5000, 104, 100), 0, "pong: at threshold");
+    // zero speed
+    struct ScrollConfig slow = CFG;
+    slow.speed_px_per_sec = 0;
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &slow, 5000, 200, 100), 0, "wrap: zero speed");
+}
+
+static void test_wrap(void)
+{
+    // text 200, viewport 100 -> overflow 100, period = 200 + gap(40) = 240
+    // start pause holds at 0
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 0, 200, 100), 0, "wrap: t=0 paused");
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 1000, 200, 100), 0, "wrap: t=start_pause boundary paused");
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 1010, 200, 100), 1, "wrap: 10ms after pause -> 1px");
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 2000, 200, 100), 100, "wrap: 1000ms of travel -> 100px");
+    // full period travelled wraps back to 0 (1000 pause + 2400ms travel = 240px)
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 3400, 200, 100), 0, "wrap: one period wraps to 0");
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 3410, 200, 100), 1, "wrap: just past wrap -> 1px");
+    // huge elapsed stays bounded and correct (exercises 64-bit math, no overflow)
+    CHECK_EQ(TextScroll_Offset(SCROLL_WRAP, &CFG, 4000000000u, 200, 100), 60, "wrap: large elapsed bounded");
+}
+
+static void test_pong(void)
+{
+    // text 200, viewport 100 -> overflow 100, travel_ms = 1000, cycle = 4000
+    // phases: [0,1000) hold@0, [1000,2000) ramp up, [2000,3000) hold@100, [3000,4000) ramp down
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 0, 200, 100), 0, "pong: t=0 hold start");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 500, 200, 100), 0, "pong: mid start pause");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 1000, 200, 100), 0, "pong: ramp-up start");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 1500, 200, 100), 50, "pong: mid ramp-up");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 1999, 200, 100), 99, "pong: end of ramp-up clamps under overflow");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 2000, 200, 100), 100, "pong: hold at end");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 2500, 200, 100), 100, "pong: mid end pause");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 3000, 200, 100), 100, "pong: ramp-down start");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 3500, 200, 100), 50, "pong: mid ramp-down (symmetric)");
+    // cycle repeats
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 4000, 200, 100), 0, "pong: cycle wraps to 0");
+    CHECK_EQ(TextScroll_Offset(SCROLL_PONG, &CFG, 5500, 200, 100), 50, "pong: second cycle mid ramp-up");
+    // never exceeds overflow across a full sweep
+    for (unsigned int t = 0; t < 4000; t += 7)
+    {
+        int off = TextScroll_Offset(SCROLL_PONG, &CFG, t, 200, 100);
+        if (off < 0 || off > 100)
+        {
+            failures++;
+            fprintf(stderr, "FAIL: pong offset out of range at t=%u (got %d)\n", t, off);
+        }
+        checks++;
+    }
+}
+
+int main(void)
+{
+    test_parse();
+    test_guards();
+    test_wrap();
+    test_pong();
+
+    if (failures == 0)
+    {
+        printf("ok - all %d checks passed\n", checks);
+        return 0;
+    }
+
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -63,6 +63,36 @@ setup() {
     [[ "$output" != *"unrecognized option"* ]]
 }
 
+# issue 12 - --scroll-method autoscroll
+
+@test "--scroll-method wrap is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --scroll-method wrap
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"Invalid scroll method"* ]]
+    [[ "$output" != *"unrecognized option"* ]]
+}
+
+@test "--scroll-method pong is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --scroll-method pong
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"Invalid scroll method"* ]]
+}
+
+@test "--scroll-method false is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --scroll-method false
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"Invalid scroll method"* ]]
+}
+
+@test "invalid scroll method is rejected" {
+    run "$BIN" --file "$TESTFILE" --scroll-method bounce
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid scroll method provided"* ]]
+}
+
 # surviving validation
 
 @test "invalid format is rejected" {


### PR DESCRIPTION
Closes #12.

Long list item names are currently truncated with an ellipsis, so a name that does not fit the row can never be read in full. This adds an opt-in `--scroll-method` option, and a matching top-level `scroll_method` JSON property, that horizontally autoscrolls the selected item's name when it is too long to fit.

The supported values are `false` (the default, which keeps the existing ellipsis truncation), `wrap` for a continuous looping marquee, and `pong` which scrolls to the end, pauses, and scrolls back to the start. Only the currently selected item scrolls; other long items keep the ellipsis, and a scrolling item is always rendered left-aligned. When the `scroll_method` JSON property is present it takes precedence over the flag.

```shell
minui-list --file list.json --scroll-method wrap
minui-list --file list.json --scroll-method pong
```
