### PR TITLE
fix: display volume and brightness settings hint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_hint.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_hint.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
   ifneq (,$(filter $(PLATFORM),tg5050 h700))
@@ -104,6 +104,8 @@ test:
 	./tmp/list_nav_test
 	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_scroll_test.c list_scroll.c -o tmp/list_scroll_test
 	./tmp/list_scroll_test
+	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_hint_test.c list_hint.c -o tmp/list_hint_test
+	./tmp/list_hint_test
 
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -48,11 +48,19 @@ The following keyboard keys are mapped to controller buttons:
 | Select | ' (apostrophe) |
 | Menu | Space |
 | Power | Backspace |
+| Minus | - (hyphen) |
+| Plus | = (equals) |
 
 L1 (E) and R1 (R) drive alphabetical scrolling when `--alphabetic-scroll` is enabled: R1 jumps
 to the next letter group and L1 to the previous one, wrapping around at the ends of the list.
 
-The L2/R2/L3/R3 and Plus/Minus buttons are not mapped.
+Minus (-) and Plus (=) adjust the volume and raise the settings overlay: the level bar in the
+top-right and a hint pill in the bottom-left. On macOS these are wired only so the overlay can be
+exercised; there is no backend to actually change the system volume, so the bar shows a fixed
+representative level. Brightness uses the Menu (Space) modifier on device, but minui-list exits on
+Menu release, so brightness is not a clean interaction on macOS.
+
+The L2/R2/L3/R3 buttons are not mapped.
 
 ## Quitting
 

--- a/list_hint.c
+++ b/list_hint.c
@@ -1,0 +1,20 @@
+#include "list_hint.h"
+
+enum BottomLeftHint BottomLeftHint_For(bool show_hardware_group,
+                                       int show_setting,
+                                       bool has_left_button_group,
+                                       bool hdmi_connected)
+{
+    // the hardware group is hidden, or the enable/action group already owns the
+    // bottom-left slot, so nothing is drawn here
+    if (!show_hardware_group || has_left_button_group)
+        return BOTTOM_LEFT_NONE;
+
+    // a volume/brightness setting is being changed - show its hint, unless HDMI
+    // is connected (the on-screen settings hints are suppressed on HDMI)
+    if (show_setting != 0 && !hdmi_connected)
+        return BOTTOM_LEFT_SETTING_HINT;
+
+    // otherwise fall back to the default power/sleep hint
+    return BOTTOM_LEFT_SLEEP;
+}

--- a/list_hint.h
+++ b/list_hint.h
@@ -1,0 +1,43 @@
+#ifndef LIST_HINT_H
+#define LIST_HINT_H
+
+#include <stdbool.h>
+
+// list_hint provides the SDL-free decision behind what minui-list draws in the
+// bottom-left pill slot each frame. Keeping it display-free means it can be unit
+// tested with the host compiler (see tests/list_hint_test.c); the caller does the
+// actual blitting.
+
+// BottomLeftHint enumerates what belongs in the bottom-left pill slot.
+enum BottomLeftHint
+{
+    // the slot is not drawn here: either the hardware group is hidden, or the
+    // enable/action button group already occupies it (drawn elsewhere)
+    BOTTOM_LEFT_NONE = 0,
+    // the volume/brightness settings hint (GFX_blitHardwareHints)
+    BOTTOM_LEFT_SETTING_HINT,
+    // the default POWER/MENU + SLEEP pill (GFX_blitButtonGroup)
+    BOTTOM_LEFT_SLEEP,
+};
+
+// BottomLeftHint_For decides what belongs in the bottom-left pill slot.
+//
+// show_hardware_group: whether the hardware group is shown at all (the
+//   --hide-hardware-group flag turns it off).
+// show_setting: the active settings overlay, matching the MinUI SDK convention
+//   returned by PWR_update: 0 = none, 1 = brightness, 2 = volume.
+// has_left_button_group: whether an enable/action button group already occupies
+//   the bottom-left slot (drawn by draw_screen).
+// hdmi_connected: whether HDMI is connected, which suppresses the on-screen
+//   settings hints.
+//
+// Returns BOTTOM_LEFT_NONE when the hardware group is hidden or the slot is
+// taken by the enable/action group; BOTTOM_LEFT_SETTING_HINT when a
+// volume/brightness setting is active and HDMI is not connected; otherwise
+// BOTTOM_LEFT_SLEEP.
+enum BottomLeftHint BottomLeftHint_For(bool show_hardware_group,
+                                       int show_setting,
+                                       bool has_left_button_group,
+                                       bool hdmi_connected);
+
+#endif // LIST_HINT_H

--- a/minui-list.c
+++ b/minui-list.c
@@ -19,6 +19,7 @@
 #include "api.h"
 #include "utils.h"
 
+#include "list_hint.h"
 #include "list_nav.h"
 #include "list_scroll.h"
 
@@ -191,7 +192,8 @@ struct AppState
     int redraw;
     // whether to show the hardware group
     int show_hardware_group;
-    // whether to show the brightness or hardware state
+    // which hardware settings overlay to show, matching the MinUI SDK
+    // convention written back by PWR_update: 0 = none, 1 = brightness, 2 = volume
     int show_brightness_setting;
     // the button to display on the Action button
     char action_button[1024];
@@ -3019,7 +3021,10 @@ int main(int argc, char *argv[])
 
         // handle turning the on/off screen on/off
         // as well as general power management
-        PWR_update(&state.redraw, NULL, NULL, NULL);
+        // the second argument receives the active settings overlay
+        // (0 = none, 1 = brightness, 2 = volume) so the volume/brightness
+        // bar and hint can be drawn while the user changes those settings
+        PWR_update(&state.redraw, &state.show_brightness_setting, NULL, NULL);
         bool power_redraw = false;
         if (state.redraw)
         {
@@ -3071,21 +3076,23 @@ int main(int argc, char *argv[])
             int ow = 0;
             if (state.show_hardware_group)
             {
-                // draw the hardware information in the top-right
+                // draw the hardware information in the top-right (battery/wifi,
+                // or the volume/brightness bar while a setting is being changed)
                 ow = GFX_blitHardwareGroup(screen, state.show_brightness_setting);
+            }
 
-                if (!has_left_button_group(&state, state.list_state))
-                {
-                    // draw the setting hints
-                    if (state.show_brightness_setting && !GetHDMI())
-                    {
-                        GFX_blitHardwareHints(screen, state.show_brightness_setting);
-                    }
-                    else
-                    {
-                        GFX_blitButtonGroup((char *[]){BTN_SLEEP == BTN_POWER ? "POWER" : "MENU", "SLEEP", NULL}, 0, screen, 0);
-                    }
-                }
+            // decide what belongs in the bottom-left pill slot
+            switch (BottomLeftHint_For(state.show_hardware_group, state.show_brightness_setting, has_left_button_group(&state, state.list_state), GetHDMI()))
+            {
+            case BOTTOM_LEFT_SETTING_HINT:
+                // draw the volume/brightness setting hint
+                GFX_blitHardwareHints(screen, state.show_brightness_setting);
+                break;
+            case BOTTOM_LEFT_SLEEP:
+                GFX_blitButtonGroup((char *[]){BTN_SLEEP == BTN_POWER ? "POWER" : "MENU", "SLEEP", NULL}, 0, screen, 0);
+                break;
+            case BOTTOM_LEFT_NONE:
+                break;
             }
 
             // your draw logic goes here

--- a/platforms/macos/platform/platform.c
+++ b/platforms/macos/platform/platform.c
@@ -21,14 +21,28 @@
 void InitSettings(void){}
 void QuitSettings(void){}
 
-int GetBrightness(void) { return 0; }
-int GetVolume(void) { return 0; }
+// there is no keymon on macOS to drive these, so the shim stores the values
+// itself (initialized to mid-range) purely so the on-screen settings overlay
+// renders a visible level while developing/verifying
+static int macos_brightness = 5; // 0-10
+static int macos_volume = 10;    // 0-20
+
+int GetBrightness(void) { return macos_brightness; }
+int GetVolume(void) { return macos_volume; }
 
 void SetRawBrightness(int value) {}
 void SetRawVolume(int value){}
 
-void SetBrightness(int value) {}
-void SetVolume(int value) {}
+void SetBrightness(int value) {
+	if (value < BRIGHTNESS_MIN) value = BRIGHTNESS_MIN;
+	if (value > BRIGHTNESS_MAX) value = BRIGHTNESS_MAX;
+	macos_brightness = value;
+}
+void SetVolume(int value) {
+	if (value < VOLUME_MIN) value = VOLUME_MIN;
+	if (value > VOLUME_MAX) value = VOLUME_MAX;
+	macos_volume = value;
+}
 
 int GetJack(void) { return 0; }
 void SetJack(int value) {}

--- a/platforms/macos/platform/platform.h
+++ b/platforms/macos/platform/platform.h
@@ -60,8 +60,8 @@
 #define CODE_MENU		44
 #define CODE_POWER		42
 
-#define CODE_PLUS		CODE_NA
-#define CODE_MINUS		CODE_NA
+#define CODE_PLUS		46	// = key for Plus (volume/brightness up)
+#define CODE_MINUS		45	// - key for Minus (volume/brightness down)
 
 ///////////////////////////////
 						// HATS

--- a/tests/list_hint_test.c
+++ b/tests/list_hint_test.c
@@ -1,0 +1,85 @@
+// Unit tests for the pure bottom-left hint decision helper. These have no
+// SDL/display dependencies, so they run headless with the host compiler via
+// `make test`.
+
+#include "list_hint.h"
+
+#include <stdio.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected, msg)                                         \
+    do                                                                          \
+    {                                                                           \
+        checks++;                                                               \
+        int _a = (actual);                                                      \
+        int _e = (expected);                                                    \
+        if (_a != _e)                                                           \
+        {                                                                       \
+            failures++;                                                         \
+            fprintf(stderr, "FAIL: %s (expected %d, got %d)\n", (msg), _e, _a); \
+        }                                                                       \
+    } while (0)
+
+// setting values, matching the MinUI SDK convention
+#define SETTING_NONE 0
+#define SETTING_BRIGHTNESS 1
+#define SETTING_VOLUME 2
+
+// regression: issue 71 - the volume/brightness setting hint must show while the
+// setting is being changed (previously it never did because the state was never
+// updated). both volume and brightness must yield the hint.
+static void test_active_setting_shows_hint(void)
+{
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_VOLUME, false, false), BOTTOM_LEFT_SETTING_HINT, "volume active -> setting hint");
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_BRIGHTNESS, false, false), BOTTOM_LEFT_SETTING_HINT, "brightness active -> setting hint");
+}
+
+// no active setting falls back to the default power/sleep hint
+static void test_no_setting_shows_sleep(void)
+{
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_NONE, false, false), BOTTOM_LEFT_SLEEP, "no setting -> sleep");
+}
+
+// HDMI suppresses the on-screen settings hints, so the slot falls back to sleep
+static void test_hdmi_suppresses_hint(void)
+{
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_VOLUME, false, true), BOTTOM_LEFT_SLEEP, "volume active + hdmi -> sleep");
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_BRIGHTNESS, false, true), BOTTOM_LEFT_SLEEP, "brightness active + hdmi -> sleep");
+}
+
+// when the enable/action group occupies the slot, nothing else is drawn there,
+// regardless of the setting state
+static void test_left_group_takes_precedence(void)
+{
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_VOLUME, true, false), BOTTOM_LEFT_NONE, "left group + volume -> none");
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_NONE, true, false), BOTTOM_LEFT_NONE, "left group + no setting -> none");
+    CHECK_EQ(BottomLeftHint_For(true, SETTING_BRIGHTNESS, true, true), BOTTOM_LEFT_NONE, "left group wins over everything");
+}
+
+// --hide-hardware-group turns off the whole block, so nothing is drawn here
+static void test_hidden_hardware_group(void)
+{
+    CHECK_EQ(BottomLeftHint_For(false, SETTING_VOLUME, false, false), BOTTOM_LEFT_NONE, "hardware group hidden + volume -> none");
+    CHECK_EQ(BottomLeftHint_For(false, SETTING_NONE, false, false), BOTTOM_LEFT_NONE, "hardware group hidden + no setting -> none");
+    CHECK_EQ(BottomLeftHint_For(false, SETTING_BRIGHTNESS, true, true), BOTTOM_LEFT_NONE, "hardware group hidden dominates");
+}
+
+int main(void)
+{
+    test_active_setting_shows_hint();
+    test_no_setting_shows_sleep();
+    test_hdmi_suppresses_hint();
+    test_left_group_takes_precedence();
+    test_hidden_hardware_group();
+
+    if (failures == 0)
+    {
+        printf("ok - all %d checks passed\n", checks);
+        return 0;
+    }
+
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}


### PR DESCRIPTION
The volume and brightness settings overlay was never tracked in the main loop, so its level bar and hint never rendered while the user changed those settings. Track the active setting so the bar and hint display, matching stock MinUI.

Fixes #71.