### PR TITLE
feat: display per-item images on the right-hand side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c list_hint.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_hint.c list_image.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c list_hint.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_hint.c list_image.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
   ifneq (,$(filter $(PLATFORM),tg5050 h700))
@@ -106,6 +106,8 @@ test:
 	./tmp/list_scroll_test
 	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_hint_test.c list_hint.c -o tmp/list_hint_test
 	./tmp/list_hint_test
+	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_image_test.c list_image.c -o tmp/list_image_test
+	./tmp/list_image_test
 
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ minui-list --file list.json --write-location file.txt
 minui-list --file list.json --background-color "#ababab"
 minui-list --file list.json --background-image "full/path/to/image.png"
 
+# a per-item image can be shown on the right-hand side of each row (json only)
+# it is scaled to fit within a third of the screen width and the row height,
+# and the item text is truncated to the remaining space
+# images are set per item via the "features.images" property below
+
+# an item can supply resolution-specific images via its "features.images" map
+# --screen-resolution selects which entry to use (a "WIDTHxHEIGHT" string)
+# by default the device resolution is auto-detected, so this only needs to be
+# set to override the detected value
+minui-list --file list.json --screen-resolution 1280x720
+
+# show a fallback image when an item that specifies an image has no
+# currently-existing file at its resolved path
+minui-list --file list.json --fallback-image "full/path/to/fallback.png"
+
 # specify a title for the list page
 # by default, the title is empty
 minui-list --file list.json --title "Some Title"
@@ -271,6 +286,7 @@ Item properties:
 - features.hide_action: (optional, type: `boolean`, default: `false`) whether to show the action button on this entry or not
 - features.hide_cancel: (optional, type: `boolean`, default: `false`) whether to show the cancel button on this entry or not
 - features.hide_confirm: (optional, type: `boolean`, default: `false`) whether to show the confirm button on this entry or not
+- features.images: (optional, type: `object`, default: `{}`) a map of resolution key to image path for an image shown on the right-hand side of the item's row. Keys are either `default` or a `WIDTHxHEIGHT` string (e.g. `1280x720`); a single image is expressed as `{"default": "full/path/to/image.png"}`. The entry matching the active resolution is used, falling back to the `default` entry when there is no exact match. The active resolution is auto-detected from the device and can be overridden with `--screen-resolution`. Each image is scaled down to fit within a third of the screen width and the row height (aspect ratio preserved; images already smaller are shown at their native size), and the item text is truncated to the remaining space. If the resolved file does not exist, nothing is drawn (or the `--fallback-image`, if set); the path is re-checked continuously, so the image appears as soon as the file exists.
 - features.show_confirm: (optional, type: `boolean`, default: `false`) whether to show the confirm button on this entry or not
 - features.is_header: (optional, type: `boolean`, default: `false`) allows specifying that an item is a header
 - features.unselectable: (optional, type: `boolean`, default: `false`) whether an item is selectable or not
@@ -297,6 +313,10 @@ Item example:
     "hide_action": false,
     "hide_cancel": false,
     "hide_confirm": false,
+    "images": {
+      "default": "full/path/to/default.png",
+      "1280x720": "full/path/to/1280x720.png"
+    },
     "is_header": false,
     "unselectable": false
   }
@@ -342,7 +362,7 @@ bats tests/
 MINUI_LIST_BIN=./minui-list-macos bats tests/
 ```
 
-Navigation logic that does not depend on a display, such as the L1/R1 alphabetic letter-jump, is covered by pure C unit tests in `tests/list_nav_test.c`. They build with the host compiler and need no SDL or cross toolchain:
+Logic that does not depend on a display is covered by pure C unit tests under `tests/`, such as the L1/R1 alphabetic letter-jump (`tests/list_nav_test.c`) and the per-item image scaling and resolution selection (`tests/list_image_test.c`). They build with the host compiler and need no SDL or cross toolchain:
 
 ```shell
 # build and run the C unit tests

--- a/list_image.c
+++ b/list_image.c
@@ -1,0 +1,69 @@
+#include "list_image.h"
+
+#include <string.h>
+
+bool ImageFit_Scale(int src_w, int src_h, int max_w, int max_h,
+                    int *dst_w, int *dst_h)
+{
+    if (dst_w != NULL)
+        *dst_w = 0;
+    if (dst_h != NULL)
+        *dst_h = 0;
+
+    if (src_w <= 0 || src_h <= 0 || max_w <= 0 || max_h <= 0)
+        return false;
+
+    int w;
+    int h;
+
+    // downscale-only: leave an image that already fits at its native size
+    if (src_w <= max_w && src_h <= max_h)
+    {
+        w = src_w;
+        h = src_h;
+    }
+    // pick the constraining dimension and scale the other with integer math so
+    // the result is deterministic (and easy to unit test)
+    else if ((long)src_w * max_h >= (long)src_h * max_w)
+    {
+        // width-constrained
+        w = max_w;
+        h = (int)((long)src_h * max_w / src_w);
+    }
+    else
+    {
+        // height-constrained
+        h = max_h;
+        w = (int)((long)src_w * max_h / src_h);
+    }
+
+    if (w < 1)
+        w = 1;
+    if (h < 1)
+        h = 1;
+
+    if (dst_w != NULL)
+        *dst_w = w;
+    if (dst_h != NULL)
+        *dst_h = h;
+
+    return true;
+}
+
+int ImageVariant_SelectIndex(const struct ImageVariant *variants, int count,
+                             const char *resolution)
+{
+    if (variants == NULL || count <= 0)
+        return -1;
+
+    int default_index = -1;
+    for (int i = 0; i < count; i++)
+    {
+        if (resolution != NULL && strcmp(variants[i].resolution, resolution) == 0)
+            return i;
+        if (strcmp(variants[i].resolution, "default") == 0)
+            default_index = i;
+    }
+
+    return default_index;
+}

--- a/list_image.h
+++ b/list_image.h
@@ -1,0 +1,41 @@
+#ifndef LIST_IMAGE_H
+#define LIST_IMAGE_H
+
+#include <stdbool.h>
+
+// list_image provides the SDL-free math and lookups behind per-item images
+// drawn on the right-hand side of a list row. It only computes scaled
+// dimensions and selects a path for the active resolution; the caller loads,
+// scales, and blits the actual surface. Keeping it display-free means it can be
+// unit tested with the host compiler (see tests/list_image_test.c).
+
+// ImageVariant maps a resolution key to an image path. The key is either
+// "default" or a "WIDTHxHEIGHT" string (e.g. "1280x720"). The path is a full
+// filesystem path to the image.
+struct ImageVariant
+{
+    // the resolution key ("default" or "WIDTHxHEIGHT")
+    char resolution[32];
+    // the full path to the image for this resolution
+    char path[1024];
+};
+
+// ImageFit_Scale computes aspect-fit ("contain") dimensions for an image of
+// src_w x src_h drawn into a box of max_w x max_h, preserving the aspect ratio.
+// It is downscale-only: an image already within the box keeps its native size
+// and is never enlarged. The result is written to *dst_w / *dst_h (each at
+// least 1 when the call succeeds).
+//
+// Returns false (and sets *dst_w / *dst_h to 0) for any non-positive input.
+bool ImageFit_Scale(int src_w, int src_h, int max_w, int max_h,
+                    int *dst_w, int *dst_h);
+
+// ImageVariant_SelectIndex returns the index of the best matching variant for
+// the given resolution: an exact resolution match if present, otherwise the
+// "default" entry, otherwise -1. Passing a NULL array, a non-positive count, or
+// a NULL resolution never matches an exact key (but a "default" entry, if any,
+// is still returned).
+int ImageVariant_SelectIndex(const struct ImageVariant *variants, int count,
+                             const char *resolution);
+
+#endif // LIST_IMAGE_H

--- a/minui-list.c
+++ b/minui-list.c
@@ -20,8 +20,12 @@
 #include "utils.h"
 
 #include "list_hint.h"
+#include "list_image.h"
 #include "list_nav.h"
 #include "list_scroll.h"
+
+// the largest image column width is a third of the screen width, per issue #13
+#define IMAGE_MAX_WIDTH_DIVISOR 3
 
 // Platform compatibility: tg5050 (NextUI) uses PWR_isOnline instead of PLAT_isOnline
 #ifdef PLATFORM_NEXTUI
@@ -145,6 +149,22 @@ struct ListItem
     int initial_selected;
     // the features of the item
     struct ListItemFeature features;
+
+    // whether the item specifies a right-hand-side image (image/images, in the
+    // item object or under features)
+    bool has_image;
+    // the per-resolution image variants (heap array sized to image_variant_count)
+    struct ImageVariant *image_variants;
+    // the number of image variants
+    int image_variant_count;
+
+    // the image path selected for the active screen resolution, fixed for the
+    // run (empty when no variant matches and there is no "default")
+    char resolved_path[1024];
+    // the path image_surface was loaded from (empty when nothing is cached)
+    char image_active_path[1024];
+    // the cached, pre-scaled image surface (NULL when nothing is loaded)
+    SDL_Surface *image_surface;
 };
 
 // ListState holds the state of the list
@@ -203,6 +223,12 @@ struct AppState
     char background_image[1024];
     // the background color to display
     char background_color[1024];
+    // the screen resolution ("WIDTHxHEIGHT") used to pick per-item images from
+    // an "images" map; empty means auto-detect from the device resolution
+    char screen_resolution[32];
+    // a full path to a fallback image shown when an item that specifies an image
+    // has no currently-existing resolved file; empty means no fallback
+    char fallback_image[1024];
     // the button to display on the Confirm button
     char confirm_button[1024];
     // the text to display on the Confirm button
@@ -360,6 +386,108 @@ static int compare_items_alphabetic(const void *a, const void *b)
     return strcasecmp(item_a->name, item_b->name);
 }
 
+// validate_features_images checks the optional "images" map on an item's
+// "features" object: it must be an object whose values are all strings. Keys are
+// left unvalidated so new resolution strings stay forward-compatible. Writes a
+// human-readable message into err and returns false on the first problem;
+// returns true when the features object is NULL or the key is absent or
+// well-formed.
+static bool validate_features_images(JSON_Object *features, const char *item_desc, char *err, size_t err_size)
+{
+    if (features == NULL)
+        return true;
+
+    JSON_Value *images_value = json_object_get_value(features, "images");
+    if (images_value == NULL)
+        return true;
+
+    if (json_value_get_type(images_value) != JSONObject)
+    {
+        snprintf(err, err_size, "%s features.images must be an object mapping resolution to path", item_desc);
+        return false;
+    }
+
+    JSON_Object *images = json_value_get_object(images_value);
+    size_t images_count = json_object_get_count(images);
+    for (size_t k = 0; k < images_count; k++)
+    {
+        if (json_value_get_type(json_object_get_value_at(images, k)) != JSONString)
+        {
+            const char *key = json_object_get_name(images, k);
+            snprintf(err, err_size, "%s features.images entry '%s' must be a string", item_desc, key ? key : "");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// ListItem_InitImage resets a list item's per-item image fields to their empty
+// defaults. Called from every item-construction branch so items that do not use
+// images (text format, string arrays, objects without image keys) are safe to
+// render and free.
+static void ListItem_InitImage(struct ListItem *item)
+{
+    item->has_image = false;
+    item->image_variants = NULL;
+    item->image_variant_count = 0;
+    item->resolved_path[0] = '\0';
+    item->image_active_path[0] = '\0';
+    item->image_surface = NULL;
+}
+
+// ListItem_UpsertVariant sets or replaces the path for a resolution key in the
+// item's variant array, growing it as needed (mirroring the options heap array).
+// Empty resolutions or paths are ignored, so callers can pass optional keys
+// directly.
+static void ListItem_UpsertVariant(struct ListItem *item, const char *resolution, const char *path)
+{
+    if (resolution == NULL || resolution[0] == '\0' || path == NULL || path[0] == '\0')
+        return;
+
+    for (int k = 0; k < item->image_variant_count; k++)
+    {
+        if (strcmp(item->image_variants[k].resolution, resolution) == 0)
+        {
+            strncpy(item->image_variants[k].path, path, sizeof(item->image_variants[k].path) - 1);
+            item->image_variants[k].path[sizeof(item->image_variants[k].path) - 1] = '\0';
+            return;
+        }
+    }
+
+    struct ImageVariant *grown = realloc(item->image_variants, sizeof(struct ImageVariant) * (item->image_variant_count + 1));
+    if (grown == NULL)
+        return;
+    item->image_variants = grown;
+
+    struct ImageVariant *variant = &item->image_variants[item->image_variant_count];
+    memset(variant, 0, sizeof(*variant));
+    strncpy(variant->resolution, resolution, sizeof(variant->resolution) - 1);
+    strncpy(variant->path, path, sizeof(variant->path) - 1);
+    item->image_variant_count++;
+}
+
+// ListItem_ReadImages reads the optional "images" map from an item's "features"
+// object into the item's variant array. Keys are resolution strings ("default"
+// or "WIDTHxHEIGHT"); the "default" entry is used when no exact match is found.
+static void ListItem_ReadImages(struct ListItem *item, JSON_Object *features)
+{
+    if (features == NULL)
+        return;
+
+    JSON_Object *images = json_object_get_object(features, "images");
+    if (images == NULL)
+        return;
+
+    size_t images_count = json_object_get_count(images);
+    for (size_t k = 0; k < images_count; k++)
+    {
+        const char *resolution = json_object_get_name(images, k);
+        const char *path = json_value_get_string(json_object_get_value_at(images, k));
+        ListItem_UpsertVariant(item, resolution, path);
+    }
+}
+
 // ListState_New creates a new ListState from a JSON file
 struct ListState *ListState_New(const char *filename, const char *format, const char *item_key, const char *confirm_text, const char *default_background_image, const char *default_background_color, struct AppState *app_state)
 {
@@ -447,6 +575,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
                 state->items[item_index].options = NULL;
                 state->items[item_index].selected = 0;
                 state->items[item_index].initial_selected = 0;
+                ListItem_InitImage(&state->items[item_index]);
                 state->items[item_index].features = (struct ListItemFeature){
                     .background_color = "",
                     .background_image = "",
@@ -605,10 +734,17 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
             }
             else
             {
-                const char *element_name = json_object_get_string(json_value_get_object(element), "name");
+                JSON_Object *element_object = json_value_get_object(element);
+                const char *element_name = json_object_get_string(element_object, "name");
                 if (element_name == NULL || element_name[0] == '\0')
                 {
                     snprintf(error_message, sizeof(error_message), "Item %zu under key '%s' is missing a name", i, item_key);
+                }
+                else
+                {
+                    char item_desc[160];
+                    snprintf(item_desc, sizeof(item_desc), "Item %zu under key '%s'", i, item_key);
+                    validate_features_images(json_object_get_object(element_object, "features"), item_desc, error_message, sizeof(error_message));
                 }
             }
         }
@@ -640,6 +776,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
             state->items[i].options = NULL;
             state->items[i].selected = 0;
             state->items[i].initial_selected = 0;
+            ListItem_InitImage(&state->items[i]);
             state->items[i].features = (struct ListItemFeature){
                 .background_color = "",
                 .background_image = "",
@@ -750,6 +887,7 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
             }
 
             state->items[i].initial_selected = state->items[i].selected;
+            ListItem_InitImage(&state->items[i]);
 
             state->items[i].features = (struct ListItemFeature){
                 .background_color = "",
@@ -1084,6 +1222,11 @@ struct ListState *ListState_New(const char *filename, const char *format, const 
                     state->items[i].features.has_background_color = false;
                 }
             }
+
+            // build the right-hand-side image variants for this item from
+            // features.images
+            ListItem_ReadImages(&state->items[i], json_object_get_object(item, "features"));
+            state->items[i].has_image = state->items[i].image_variant_count > 0;
         }
     }
 
@@ -1157,6 +1300,40 @@ void ListState_InitView(struct ListState *state, int max_row_count)
     }
 }
 
+// ListState_ResolveImages selects each item's right-hand image path for the
+// active screen resolution. It must run after display init so FIXED_WIDTH and
+// FIXED_HEIGHT reflect the real device. The resolution key is the
+// --screen-resolution override when set, otherwise the device's native
+// WIDTHxHEIGHT.
+void ListState_ResolveImages(struct ListState *state, struct AppState *app_state)
+{
+    char resolution[32];
+    if (app_state->screen_resolution[0] != '\0')
+    {
+        strncpy(resolution, app_state->screen_resolution, sizeof(resolution) - 1);
+        resolution[sizeof(resolution) - 1] = '\0';
+    }
+    else
+    {
+        snprintf(resolution, sizeof(resolution), "%dx%d", FIXED_WIDTH, FIXED_HEIGHT);
+    }
+
+    for (size_t i = 0; i < state->item_count; i++)
+    {
+        struct ListItem *item = &state->items[i];
+        item->resolved_path[0] = '\0';
+        if (!item->has_image)
+            continue;
+
+        int idx = ImageVariant_SelectIndex(item->image_variants, item->image_variant_count, resolution);
+        if (idx >= 0)
+        {
+            strncpy(item->resolved_path, item->image_variants[idx].path, sizeof(item->resolved_path) - 1);
+            item->resolved_path[sizeof(item->resolved_path) - 1] = '\0';
+        }
+    }
+}
+
 // alphabetic_jump_target builds an SDL-free navigation view of the list and
 // returns the index to jump to for an alphabetic (L1/R1) letter jump. `forward`
 // selects next-letter (true) or previous-letter (false). Returns the current
@@ -1185,6 +1362,10 @@ static int alphabetic_jump_target(struct ListState *state, bool forward)
     return target;
 }
 
+// image_effective_path is defined alongside the other drawing helpers below but
+// is also polled here in handle_input, so it needs a forward declaration.
+void image_effective_path(struct ListItem *item, const char *fallback_image, char *out, size_t out_size);
+
 // handle_input interprets input events and mutates app state
 void handle_input(struct AppState *state)
 {
@@ -1196,6 +1377,23 @@ void handle_input(struct AppState *state)
         if (access(state->list_state->items[state->list_state->selected].features.background_image, F_OK) != -1)
         {
             state->list_state->items[state->list_state->selected].features.background_image_exists = true;
+            state->redraw = 1;
+        }
+    }
+
+    // poll visible items' right-hand images so a missing file that later appears
+    // (or a fallback that swaps in or out) forces a redraw; draw_screen then
+    // reloads the cached surface from the new effective path
+    for (int i = state->list_state->first_visible; i < state->list_state->last_visible; i++)
+    {
+        struct ListItem *item = &state->list_state->items[i];
+        if (!item->has_image)
+            continue;
+
+        char effective[1024];
+        image_effective_path(item, state->fallback_image, effective, sizeof(effective));
+        if (strcmp(effective, item->image_active_path) != 0)
+        {
             state->redraw = 1;
         }
     }
@@ -1644,6 +1842,94 @@ SDL_Surface *scale_surface(SDL_Surface *surface,
     return scaled;
 }
 
+// image_effective_path computes the path an item should currently display: its
+// resolved per-resolution path when that file exists, otherwise the global
+// fallback image when that exists, otherwise empty. Items without an image spec
+// always resolve to empty.
+void image_effective_path(struct ListItem *item, const char *fallback_image, char *out, size_t out_size)
+{
+    out[0] = '\0';
+    if (!item->has_image)
+        return;
+
+    if (item->resolved_path[0] != '\0' && access(item->resolved_path, F_OK) != -1)
+    {
+        strncpy(out, item->resolved_path, out_size - 1);
+        out[out_size - 1] = '\0';
+        return;
+    }
+
+    if (fallback_image != NULL && fallback_image[0] != '\0' && access(fallback_image, F_OK) != -1)
+    {
+        strncpy(out, fallback_image, out_size - 1);
+        out[out_size - 1] = '\0';
+    }
+}
+
+// ensure_item_image (re)loads and caches an item's scaled right-hand image when
+// the effective path changes. It frees any previously cached surface and records
+// image_active_path so a stable path (including an empty path or a load failure)
+// is not retried every frame. max_w/max_h bound the scaled size.
+void ensure_item_image(struct ListItem *item, const char *effective, int max_w, int max_h)
+{
+    if (strcmp(effective, item->image_active_path) == 0)
+        return;
+
+    if (item->image_surface != NULL)
+    {
+        SDL_FreeSurface(item->image_surface);
+        item->image_surface = NULL;
+    }
+
+    strncpy(item->image_active_path, effective, sizeof(item->image_active_path) - 1);
+    item->image_active_path[sizeof(item->image_active_path) - 1] = '\0';
+
+    if (effective[0] == '\0')
+        return;
+
+    SDL_Surface *surface = IMG_Load(effective);
+    if (surface == NULL)
+        return;
+
+    int dst_w = 0;
+    int dst_h = 0;
+    if (!ImageFit_Scale(surface->w, surface->h, max_w, max_h, &dst_w, &dst_h))
+    {
+        SDL_FreeSurface(surface);
+        return;
+    }
+
+    SDL_Surface *scaled;
+    if (dst_w == surface->w && dst_h == surface->h)
+    {
+        scaled = surface;
+    }
+    else
+    {
+#ifdef USE_SDL2
+        scaled = SDL_CreateRGBSurfaceWithFormat(0, dst_w, dst_h, 32, SDL_PIXELFORMAT_RGBA32);
+        if (scaled != NULL)
+        {
+            // copy source pixels (including alpha) rather than compositing, so
+            // the scaled copy keeps transparency for blending over the row
+            SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE);
+            SDL_BlitScaled(surface, NULL, scaled, NULL);
+        }
+#else
+        scaled = scale_surface(surface, dst_w, dst_h);
+#endif
+        SDL_FreeSurface(surface);
+    }
+
+    if (scaled == NULL)
+        return;
+
+#ifdef USE_SDL2
+    SDL_SetSurfaceBlendMode(scaled, SDL_BLENDMODE_BLEND);
+#endif
+    item->image_surface = scaled;
+}
+
 // draw_background draws the background of the list
 bool draw_background(SDL_Surface *screen, struct AppState *state)
 {
@@ -1912,6 +2198,22 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             available_width -= color_box_space;
         }
 
+        // load this item's right-hand image (if any) and reserve a column for it
+        // on the right, shrinking the content area so the name truncates to fit.
+        // the image is capped at a third of the screen width and the row height.
+        int image_col_space = 0;
+        {
+            struct ListItem *image_item = &state->list_state->items[i];
+            char image_effective[1024];
+            image_effective_path(image_item, state->fallback_image, image_effective, sizeof(image_effective));
+            ensure_item_image(image_item, image_effective, screen->w / IMAGE_MAX_WIDTH_DIVISOR, SCALE1(PILL_SIZE - 4));
+            if (image_item->image_surface != NULL)
+            {
+                image_col_space = image_item->image_surface->w + SCALE1(PADDING);
+                available_width -= image_col_space;
+            }
+        }
+
         char truncated_display_text[256];
         int text_width = GFX_truncateText(state->fonts.large, display_text, truncated_display_text, available_width, SCALE1(BUTTON_PADDING * 2));
 
@@ -1935,7 +2237,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             {
                 int value_width = 0;
                 TTF_SizeUTF8(state->fonts.large, display_selected_text, &value_width, NULL);
-                int value_left = screen->w - value_width - SCALE1(PADDING + BUTTON_PADDING) - color_box_space;
+                int value_left = screen->w - value_width - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space;
                 int value_viewport = value_left - SCALE1(PADDING + BUTTON_PADDING) - SCALE1(PADDING);
                 if (value_viewport < scroll_viewport)
                 {
@@ -1988,11 +2290,11 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             int pill_x_pos;
             if (strcmp(alignment, "center") == 0)
             {
-                pill_x_pos = (screen->w - pill_width) / 2;
+                pill_x_pos = (screen->w - image_col_space - pill_width) / 2;
             }
             else if (strcmp(alignment, "right") == 0)
             {
-                pill_x_pos = screen->w - pill_width - SCALE1(PADDING);
+                pill_x_pos = screen->w - pill_width - SCALE1(PADDING) - image_col_space;
             }
             else // left (default)
             {
@@ -2024,7 +2326,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
 
             if (strcmp(display_selected_text, "") != 0)
             {
-                GFX_blitPill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), screen->w - SCALE1(PADDING + BUTTON_MARGIN), SCALE1(PILL_SIZE)});
+                GFX_blitPill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), screen->w - SCALE1(PADDING + BUTTON_MARGIN) - image_col_space, SCALE1(PILL_SIZE)});
             }
 
             GFX_blitPill(ASSET_WHITE_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), pill_width, SCALE1(PILL_SIZE)});
@@ -2047,13 +2349,13 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
         int shadow_x_pos;
         if (strcmp(alignment, "center") == 0)
         {
-            text_x_pos = (screen->w - text->w - color_box_space) / 2;
+            text_x_pos = (screen->w - text->w - color_box_space - image_col_space) / 2;
             shadow_x_pos = text_x_pos - 2;
         }
         else if (strcmp(alignment, "right") == 0)
         {
-            text_x_pos = screen->w - text->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space;
-            shadow_x_pos = screen->w - text->w - SCALE1(2 + PADDING + BUTTON_PADDING) - color_box_space;
+            text_x_pos = screen->w - text->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space;
+            shadow_x_pos = screen->w - text->w - SCALE1(2 + PADDING + BUTTON_PADDING) - color_box_space - image_col_space;
         }
         else // left (default)
         {
@@ -2138,7 +2440,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
         // draw the selected option text
         if (strcmp(display_selected_text, "") != 0)
         {
-            initial_cube_x_pos = screen->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space;
+            initial_cube_x_pos = screen->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space;
             if (j != 0 || strlen(state->title) > 0)
             {
                 SDL_Color selected_text_color = COLOR_WHITE;
@@ -2148,7 +2450,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
                 }
                 SDL_Surface *selected_text;
                 selected_text = TTF_RenderUTF8_Blended(state->fonts.large, display_selected_text, selected_text_color);
-                pos = (SDL_Rect){screen->w - selected_text->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space, pos.y, selected_text->w, selected_text->h};
+                pos = (SDL_Rect){screen->w - selected_text->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space, pos.y, selected_text->w, selected_text->h};
                 SDL_BlitSurface(selected_text, NULL, screen, &pos);
                 SDL_FreeSurface(selected_text);
             }
@@ -2175,6 +2477,40 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
                 SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding + 5) + 2, color_placeholder_height - 4,
                 color_placeholder_height - 4};
             SDL_FillRect(screen, &(SDL_Rect){color_rect.x, color_rect.y, color_rect.w, color_rect.h}, color);
+        }
+
+        // draw the per-item right-hand image, vertically centered in the row and
+        // anchored to the right edge (left of the hardware group on the top row)
+        if (state->list_state->items[i].image_surface != NULL)
+        {
+            SDL_Surface *image_surface = state->list_state->items[i].image_surface;
+            int image_right_edge = screen->w - SCALE1(PADDING);
+            if (in_top_row_no_title)
+            {
+                image_right_edge -= (ow + SCALE1(PADDING));
+            }
+            int row_top = SCALE1(PADDING + ((i - state->list_state->first_visible) * PILL_SIZE) + initial_list_y_padding);
+            SDL_Rect image_pos = {
+                image_right_edge - image_surface->w,
+                row_top + (SCALE1(PILL_SIZE) - image_surface->h) / 2,
+                image_surface->w,
+                image_surface->h};
+            SDL_BlitSurface(image_surface, NULL, screen, &image_pos);
+        }
+    }
+
+    // free cached image surfaces for items scrolled out of view to bound memory
+    // to roughly the visible window; they reload on demand when scrolled back in
+    for (size_t i = 0; i < state->list_state->item_count; i++)
+    {
+        if ((int)i >= state->list_state->first_visible && (int)i < state->list_state->last_visible)
+            continue;
+        struct ListItem *offscreen = &state->list_state->items[i];
+        if (offscreen->image_surface != NULL)
+        {
+            SDL_FreeSurface(offscreen->image_surface);
+            offscreen->image_surface = NULL;
+            offscreen->image_active_path[0] = '\0';
         }
     }
 
@@ -2383,6 +2719,13 @@ void signal_handler(int signal)
 // - --write-value <value> (default: "selected")
 bool parse_arguments(struct AppState *state, int argc, char *argv[])
 {
+    // long-only options use val codes above the ASCII range so they need no
+    // short flag (the short option alphabet is nearly exhausted)
+    enum
+    {
+        OPT_SCREEN_RESOLUTION = 1000,
+        OPT_FALLBACK_IMAGE,
+    };
     static struct option long_options[] = {
         {"action-button", required_argument, 0, 'a'},
         {"action-text", required_argument, 0, 'A'},
@@ -2409,6 +2752,8 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         {"always-show-confirm", no_argument, 0, 'X'},
         {"disable-auto-sleep", no_argument, 0, 'U'},
         {"alphabetic-scroll", no_argument, 0, 'S'},
+        {"screen-resolution", required_argument, 0, OPT_SCREEN_RESOLUTION},
+        {"fallback-image", required_argument, 0, OPT_FALLBACK_IMAGE},
         {0, 0, 0, 0}};
 
     int opt;
@@ -2494,6 +2839,12 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         case 'S':
             state->alphabetic_scroll = true;
             break;
+        case OPT_SCREEN_RESOLUTION:
+            strncpy(state->screen_resolution, optarg, sizeof(state->screen_resolution) - 1);
+            break;
+        case OPT_FALLBACK_IMAGE:
+            strncpy(state->fallback_image, optarg, sizeof(state->fallback_image) - 1);
+            break;
         default:
             return false;
         }
@@ -2511,6 +2862,19 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
     {
         log_error("Invalid scroll method provided. Please provide a value of 'false', 'wrap', or 'pong'.");
         return false;
+    }
+
+    // validate screen resolution format (WIDTHxHEIGHT), when provided
+    if (state->screen_resolution[0] != '\0')
+    {
+        int resolution_width = 0;
+        int resolution_height = 0;
+        char resolution_extra = '\0';
+        if (sscanf(state->screen_resolution, "%dx%d%c", &resolution_width, &resolution_height, &resolution_extra) != 2 || resolution_width <= 0 || resolution_height <= 0)
+        {
+            log_error("Invalid screen resolution provided. Please provide a value of the form WIDTHxHEIGHT, e.g. '1280x720'.");
+            return false;
+        }
     }
 
     if (strcmp(state->format, "") == 0)
@@ -2985,6 +3349,10 @@ int main(int argc, char *argv[])
 
     // validate selection and compute initial visible window
     ListState_InitView(state.list_state, state.max_row_count);
+
+    // resolve per-item images now that init() has run and FIXED_WIDTH/HEIGHT
+    // reflect the real device resolution
+    ListState_ResolveImages(state.list_state, &state);
 
     if (state.list_state->item_count == 0 || state.list_state->selected < 0)
     {

--- a/tests/list_image_test.c
+++ b/tests/list_image_test.c
@@ -1,0 +1,120 @@
+// Unit tests for the pure per-item image helpers. These have no SDL/display
+// dependencies, so they run headless with the host compiler via `make test`.
+
+#include "list_image.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected, msg)                                         \
+    do                                                                          \
+    {                                                                           \
+        checks++;                                                               \
+        int _a = (actual);                                                      \
+        int _e = (expected);                                                    \
+        if (_a != _e)                                                           \
+        {                                                                       \
+            failures++;                                                         \
+            fprintf(stderr, "FAIL: %s (expected %d, got %d)\n", (msg), _e, _a); \
+        }                                                                       \
+    } while (0)
+
+// CHECK_FIT scales src into the box and asserts the returned flag and the two
+// output dimensions in a single, readable statement.
+#define CHECK_FIT(sw, sh, mw, mh, exp_ok, exp_w, exp_h, msg)                    \
+    do                                                                          \
+    {                                                                           \
+        int _w = -1;                                                            \
+        int _h = -1;                                                            \
+        bool _ok = ImageFit_Scale((sw), (sh), (mw), (mh), &_w, &_h);            \
+        CHECK_EQ(_ok ? 1 : 0, (exp_ok) ? 1 : 0, msg " (ok)");                   \
+        CHECK_EQ(_w, (exp_w), msg " (w)");                                      \
+        CHECK_EQ(_h, (exp_h), msg " (h)");                                      \
+    } while (0)
+
+static void test_fit_downscale_only(void)
+{
+    // an image already within the box keeps its native size
+    CHECK_FIT(30, 30, 213, 54, true, 30, 30, "fit: small stays native");
+    CHECK_FIT(213, 54, 213, 54, true, 213, 54, "fit: exact box");
+    CHECK_FIT(100, 20, 213, 54, true, 100, 20, "fit: fits both dims");
+}
+
+static void test_fit_downscale(void)
+{
+    // 640x480 into 213x54 -> height-constrained -> 72x54
+    CHECK_FIT(640, 480, 213, 54, true, 72, 54, "fit: landscape height-bound");
+    // 500x40 into 213x54 -> width-constrained -> 213x17
+    CHECK_FIT(500, 40, 213, 54, true, 213, 17, "fit: wide width-bound");
+    // 100x100 into 213x54 -> height-constrained -> 54x54
+    CHECK_FIT(100, 100, 213, 54, true, 54, 54, "fit: square height-bound");
+    // 40x500 into 213x54 (taller than the row) -> height-constrained -> 4x54
+    CHECK_FIT(40, 500, 213, 54, true, 4, 54, "fit: tall portrait");
+    // width already fits but far too tall -> height-constrained
+    CHECK_FIT(213, 600, 213, 54, true, 19, 54, "fit: exact width, too tall");
+}
+
+static void test_fit_rounding_and_guards(void)
+{
+    // extreme downscale rounds up to a floor of 1px on the constrained axis
+    CHECK_FIT(1000, 10, 5, 5, true, 5, 1, "fit: rounds up to 1px");
+    // non-positive inputs fail and leave dst at 0
+    CHECK_FIT(0, 50, 213, 54, false, 0, 0, "fit: zero src width");
+    CHECK_FIT(50, 0, 213, 54, false, 0, 0, "fit: zero src height");
+    CHECK_FIT(50, 50, 0, 54, false, 0, 0, "fit: zero max width");
+    CHECK_FIT(50, 50, 213, 0, false, 0, 0, "fit: zero max height");
+    CHECK_FIT(-10, 50, 213, 54, false, 0, 0, "fit: negative src width");
+
+    // NULL out-pointers must not crash
+    checks++;
+    if (!ImageFit_Scale(640, 480, 213, 54, NULL, NULL))
+    {
+        failures++;
+        fprintf(stderr, "FAIL: fit: NULL out-pointers should still succeed\n");
+    }
+}
+
+static void test_variant_select(void)
+{
+    struct ImageVariant with_default[] = {
+        {"default", "/d.png"},
+        {"1280x720", "/hd.png"},
+    };
+    int n = (int)(sizeof(with_default) / sizeof(with_default[0]));
+
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, n, "1280x720"), 1, "select: exact match");
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, n, "640x480"), 0, "select: falls back to default");
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, n, "1024x768"), 0, "select: unknown -> default");
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, n, "default"), 0, "select: literal default key");
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, n, NULL), 0, "select: NULL resolution -> default");
+
+    struct ImageVariant no_default[] = {
+        {"1280x720", "/hd.png"},
+    };
+    CHECK_EQ(ImageVariant_SelectIndex(no_default, 1, "1280x720"), 0, "select: no-default exact");
+    CHECK_EQ(ImageVariant_SelectIndex(no_default, 1, "640x480"), -1, "select: no-default no-match");
+    CHECK_EQ(ImageVariant_SelectIndex(no_default, 1, NULL), -1, "select: no-default NULL");
+
+    CHECK_EQ(ImageVariant_SelectIndex(NULL, 0, "1280x720"), -1, "select: NULL array");
+    CHECK_EQ(ImageVariant_SelectIndex(with_default, 0, "1280x720"), -1, "select: zero count");
+}
+
+int main(void)
+{
+    test_fit_downscale_only();
+    test_fit_downscale();
+    test_fit_rounding_and_guards();
+    test_variant_select();
+
+    if (failures == 0)
+    {
+        printf("ok - all %d checks passed\n", checks);
+        return 0;
+    }
+
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -186,3 +186,48 @@ setup() {
     [[ "$output" == *"is not an object"* ]]
     [[ "$output" != *"No selectable items found"* ]]
 }
+
+# issue 13 - per-item right-hand-side images
+#
+# images live under "features.images" (a resolution -> path map, with the single
+# image expressed as features.images.default). invalid shapes must fail
+# validation (which runs before display init) rather than reach the renderer.
+
+@test "non-object features.images is rejected" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":[{"name":"Apple","features":{"images":"nope"}}]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"features.images must be an object"* ]]
+}
+
+@test "non-string features.images entry is rejected" {
+    JSONFILE="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/minui-list-json.XXXXXX")"
+    printf '{"items":[{"name":"Apple","features":{"images":{"default":123}}}]}' > "$JSONFILE"
+    run "$BIN" --file "$JSONFILE" --format json
+    [ "$status" -eq 1 ]
+    [ "$status" -ne 139 ]
+    [[ "$output" == *"features.images entry 'default' must be a string"* ]]
+}
+
+@test "--screen-resolution is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --screen-resolution 1280x720
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"Invalid screen resolution"* ]]
+    [[ "$output" != *"unrecognized option"* ]]
+}
+
+@test "invalid --screen-resolution is rejected" {
+    run "$BIN" --file "$TESTFILE" --screen-resolution 1280x
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid screen resolution provided"* ]]
+}
+
+@test "--fallback-image is accepted" {
+    run "$BIN" --file "$TESTFILE" --format xml --fallback-image /path/to/fallback.png
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid format provided"* ]]
+    [[ "$output" != *"unrecognized option"* ]]
+}


### PR DESCRIPTION
Adds an optional `features.images` map on json items that renders a resolution-aware image on the right of each row, scaling it to at most a third of the screen width and truncating the row text to fit. A single image is expressed as `features.images.default`, while `WIDTHxHEIGHT` keys select assets for a specific resolution; the active resolution is auto-detected and can be overridden with `--screen-resolution`. The `--fallback-image` flag supplies a placeholder shown while an item's image is missing, and each image path is re-checked continuously so it appears as soon as the file exists.

Closes #13.