### PR TITLE
feat: add nextui-specific binaries for tg5040 and my355

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         toolchain:
           # - gkdpixel deprecated, but also i386 only so it won't build without buildx
-          - h700
           - m17 # (deprecated)
           - magicmini
           - miyoomini # (deprecated)
@@ -35,14 +34,23 @@ jobs:
           - rgb30 # (deprecated)
           # - tg3040 now merged with tg5040, so we can't build it separately
           - tg5040
-          - tg5050
           - trimuismart # (deprecated)
           - zero28
+          # NextUI-specific builds (device also runs MinUI for tg5040/my355;
+          # tg5050/h700 are NextUI-only)
+          - tg5040-nextui
+          - my355-nextui
+          - tg5050-nextui
+          - h700-nextui
         include:
-          - toolchain: h700
-            toolchain_repo: LoveRetro/h700-toolchain
-          - toolchain: tg5050
+          - toolchain: tg5040-nextui
+            toolchain_repo: LoveRetro/tg5040-toolchain
+          - toolchain: my355-nextui
+            toolchain_repo: LoveRetro/my355-toolchain
+          - toolchain: tg5050-nextui
             toolchain_repo: LoveRetro/tg5050-toolchain
+          - toolchain: h700-nextui
+            toolchain_repo: LoveRetro/h700-toolchain
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,6 @@ jobs:
       matrix:
         toolchain:
           # - gkdpixel deprecated, but also i386 only so it won't build without buildx
-          - h700
           - m17 # (deprecated)
           - magicmini
           - miyoomini # (deprecated)
@@ -40,14 +39,23 @@ jobs:
           - rgb30 # (deprecated)
           # - tg3040 now merged with tg5040, so we can't build it separately
           - tg5040
-          - tg5050
           - trimuismart # (deprecated)
           - zero28
+          # NextUI-specific builds (device also runs MinUI for tg5040/my355;
+          # tg5050/h700 are NextUI-only)
+          - tg5040-nextui
+          - my355-nextui
+          - tg5050-nextui
+          - h700-nextui
         include:
-          - toolchain: h700
-            toolchain_repo: LoveRetro/h700-toolchain
-          - toolchain: tg5050
+          - toolchain: tg5040-nextui
+            toolchain_repo: LoveRetro/tg5040-toolchain
+          - toolchain: my355-nextui
+            toolchain_repo: LoveRetro/my355-toolchain
+          - toolchain: tg5050-nextui
             toolchain_repo: LoveRetro/tg5050-toolchain
+          - toolchain: h700-nextui
+            toolchain_repo: LoveRetro/h700-toolchain
     outputs:
       filename: ${{ steps.binary.outputs.filename }}
 
@@ -73,7 +81,7 @@ jobs:
       - name: Move the codebase to the correct location
         run: |
           mkdir -p union-${{ matrix.toolchain }}-toolchain/workspace/repo
-          mv *.c Makefile union-${{ matrix.toolchain }}-toolchain/workspace/repo
+          mv *.c *.h Makefile union-${{ matrix.toolchain }}-toolchain/workspace/repo
 
       - name: Pull the toolchain
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,40 @@ CURRENT_WORKING_DIR = $(shell pwd)
 
 PLATFORM ?= tg5040
 MINUI_VERSION ?= v20251023-0
-NEXTUI_VERSION ?= v6.9.0
+NEXTUI_VERSION ?= v6.14.0
+MY355_NEXTUI_VERSION ?= my355-latest
 H700_VERSION ?= h700-rc3
 
+# WORKSPACE is the upstream workspace directory name and the runtime device id
+# baked into the binary via -DPLATFORM. It matches PLATFORM for every platform
+# except the NextUI variants, whose PLATFORM carries a "-nextui" suffix (e.g.
+# tg5040-nextui) while their upstream workspace and on-device id remain the bare
+# device (e.g. tg5040), so that .system/.userdata paths resolve on the device.
+WORKSPACE = $(PLATFORM)
+# IS_NEXTUI is set for platforms that build against a NextUI SDK/toolchain.
+IS_NEXTUI =
+
 # Determine upstream repository based on platform
-ifeq ($(PLATFORM),tg5050)
+ifeq ($(PLATFORM),tg5040-nextui)
   UPSTREAM_REPO = https://github.com/loveRetro/NextUI
   UPSTREAM_VERSION = $(NEXTUI_VERSION)
-else ifeq ($(PLATFORM),h700)
+  WORKSPACE = tg5040
+  IS_NEXTUI = 1
+else ifeq ($(PLATFORM),my355-nextui)
+  UPSTREAM_REPO = https://github.com/loveRetro/NextUI
+  UPSTREAM_VERSION = $(MY355_NEXTUI_VERSION)
+  WORKSPACE = my355
+  IS_NEXTUI = 1
+else ifeq ($(PLATFORM),tg5050-nextui)
+  UPSTREAM_REPO = https://github.com/loveRetro/NextUI
+  UPSTREAM_VERSION = $(NEXTUI_VERSION)
+  WORKSPACE = tg5050
+  IS_NEXTUI = 1
+else ifeq ($(PLATFORM),h700-nextui)
   UPSTREAM_REPO = https://github.com/pvaibhav/NextUI
   UPSTREAM_VERSION = $(H700_VERSION)
+  WORKSPACE = h700
+  IS_NEXTUI = 1
 else
   UPSTREAM_REPO = https://github.com/shauninman/MinUI
   UPSTREAM_VERSION = $(MINUI_VERSION)
@@ -29,15 +53,15 @@ ifeq ($(PLATFORM),macos)
 else
   ifeq (,$(CROSS_COMPILE))
     # the host-only targets below do not cross-compile, so they don't need a toolchain
-    ifeq (,$(filter test clean,$(MAKECMDGOALS)))
+    ifeq (,$(filter test clean print-%,$(MAKECMDGOALS)))
       $(error missing CROSS_COMPILE for this toolchain)
     endif
   endif
   CC = $(CROSS_COMPILE)gcc
   PREFIX = $(CURRENT_WORKING_DIR)/platform/$(PLATFORM)
-  PLATFORM_DIR = minui/workspace/$(PLATFORM)/platform
+  PLATFORM_DIR = minui/workspace/$(WORKSPACE)/platform
   LD_LIBRARY_PATH = $(CURRENT_WORKING_DIR)/platform/$(PLATFORM)/lib/
-  -include minui/workspace/$(PLATFORM)/platform/makefile.env
+  -include minui/workspace/$(WORKSPACE)/platform/makefile.env
 endif
 SDL?=SDL
 
@@ -49,27 +73,30 @@ ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
   SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
-  CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
+  CFLAGS += $(INCDIR) -DPLATFORM=\"$(WORKSPACE)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
-  INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(WORKSPACE)/platform/ -Iinclude/
+  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(WORKSPACE)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
-  # tg5050/h700 use the NextUI toolchain which installs libmsettings to /opt/nextui
-  ifneq (,$(filter $(PLATFORM),tg5050 h700))
+  # NextUI toolchains install libmsettings and the GLES stack to /opt/nextui
+  ifneq (,$(IS_NEXTUI))
     INCDIR += -I/opt/nextui/include
     # tg5050's GLESv2 is backed by a separate mali blob that must be linked
-    # explicitly; h700 links libGLESv2 directly and ships no standalone libmali
+    # explicitly; the other NextUI toolchains link libGLESv2 directly and ship
+    # no standalone libmali. tg5040 needs no libsamplerate at its pinned version.
     NEXTUI_GL_LIBS = -lGLESv2 -lsamplerate
-    ifeq ($(PLATFORM),tg5050)
+    ifeq ($(PLATFORM),tg5050-nextui)
       NEXTUI_GL_LIBS = -lGLESv2 -lmali -lsamplerate
+    else ifeq ($(PLATFORM),tg5040-nextui)
+      NEXTUI_GL_LIBS = -lGLESv2
     endif
     FLAGS += -L/opt/nextui/lib $(NEXTUI_GL_LIBS)
-    CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DPLATFORM_NEXTUI
+    CFLAGS += $(INCDIR) -DPLATFORM=\"$(WORKSPACE)\" -DPLATFORM_NEXTUI
     SOURCE += minui/workspace/all/common/config.c
   else
     CFLAGS = $(ARCH) -fomit-frame-pointer
-    CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -Ofast -std=gnu99
+    CFLAGS += $(INCDIR) -DPLATFORM=\"$(WORKSPACE)\" -DUSE_$(SDL) -Ofast -std=gnu99
   endif
 endif
 
@@ -95,6 +122,11 @@ endif
 
 clean:
 	rm -rf $(PRODUCT)-$(PLATFORM)
+
+# Print the value of any make variable, e.g. `make print-UPSTREAM_REPO PLATFORM=tg5040-nextui`
+# Used by tests/makefile.bats to assert the per-platform build wiring.
+print-%:
+	@echo '$*=$($*)'
 
 # Build and run the pure-C unit tests with the host compiler (no SDL required)
 TEST_CC ?= cc
@@ -136,7 +168,7 @@ platform/$(PLATFORM)/include:
 # PREFIX is the path to the workspace (not used for macOS)
 ifneq ($(PLATFORM),macos)
 $(PREFIX)/include/msettings.h: platform/$(PLATFORM)/lib platform/$(PLATFORM)/include
-	cd $(CURRENT_WORKING_DIR)/minui/workspace/$(PLATFORM)/libmsettings && make
+	cd $(CURRENT_WORKING_DIR)/minui/workspace/$(WORKSPACE)/libmsettings && make
 endif
 
 include/parson:

--- a/Makefile
+++ b/Makefile
@@ -79,17 +79,16 @@ else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(WORKSPACE)/platform/ -Iinclude/
   SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(WORKSPACE)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
-  # NextUI toolchains install libmsettings and the GLES stack to /opt/nextui
+  # NextUI toolchains install libmsettings and the GLES stack to /opt/nextui.
+  # api.c resamples audio through libsamplerate on every NextUI target. tg5050
+  # and my355 additionally need the standalone mali blob linked explicitly
+  # because their libGLESv2 is a stub that pulls symbols from libmali; tg5040
+  # and h700 resolve libGLESv2 symbols directly.
   ifneq (,$(IS_NEXTUI))
     INCDIR += -I/opt/nextui/include
-    # tg5050's GLESv2 is backed by a separate mali blob that must be linked
-    # explicitly; the other NextUI toolchains link libGLESv2 directly and ship
-    # no standalone libmali. tg5040 needs no libsamplerate at its pinned version.
     NEXTUI_GL_LIBS = -lGLESv2 -lsamplerate
-    ifeq ($(PLATFORM),tg5050-nextui)
+    ifneq (,$(filter $(PLATFORM),tg5050-nextui my355-nextui))
       NEXTUI_GL_LIBS = -lGLESv2 -lmali -lsamplerate
-    else ifeq ($(PLATFORM),tg5040-nextui)
-      NEXTUI_GL_LIBS = -lGLESv2
     endif
     FLAGS += -L/opt/nextui/lib $(NEXTUI_GL_LIBS)
     CFLAGS += $(INCDIR) -DPLATFORM=\"$(WORKSPACE)\" -DPLATFORM_NEXTUI

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This is a minui list app. It allows people to show a list of items or settings a
 
 - todo: this is built inside-out. Ideally you can clone this into the MinUI workspace directory and build from there under each toolchain, but instead it gets cloned _into_ a toolchain workspace directory and built from there.
 
+The build platform is selected with `PLATFORM`, and the binary is named `minui-list-$(PLATFORM)`. For example, `PLATFORM=tg5040 make` produces `minui-list-tg5040`.
+
+## Supported platforms
+
+Binaries are built against one of two firmwares. Most devices build against MinUI (`shauninman/MinUI`). NextUI-specific binaries build against a NextUI toolchain and are suffixed with `-nextui`.
+
+- `tg5040` and `my355` run both firmwares, so they have a MinUI build (`minui-list-tg5040`, `minui-list-my355`) and a NextUI build (`minui-list-tg5040-nextui`, `minui-list-my355-nextui`).
+- `tg5050` and `h700` are NextUI-only and build as `minui-list-tg5050-nextui` and `minui-list-h700-nextui`.
+
+To build a NextUI variant, use its platform id inside the matching toolchain, for example `PLATFORM=tg5040-nextui make`. See [docs/nextui.md](docs/nextui.md) for the platform/toolchain matrix and how the NextUI builds are wired. For the native macOS build used by the test suite, see [docs/macos.md](docs/macos.md).
+
 ## Usage
 
 This tool is designed to be used as part of a larger minui app.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+- [macos.md](macos.md) - building and running minui-list natively on macOS (used by the test suite)
+- [nextui.md](nextui.md) - NextUI-specific builds, the platform/toolchain matrix, and how they are wired
+
+The main [README](../README.md) covers usage, CLI flags, file formats, and the supported-platforms overview.

--- a/docs/nextui.md
+++ b/docs/nextui.md
@@ -28,11 +28,10 @@ The only source-level NextUI difference is in `minui-list.c`: under `-DPLATFORM_
 
 ### GLES and audio libraries
 
-NextUI toolchains install `libmsettings` and the GLES stack under `/opt/nextui`. The linked libraries differ per device (`NEXTUI_GL_LIBS`):
+NextUI toolchains install `libmsettings` and the GLES stack under `/opt/nextui`. Every NextUI target links `libsamplerate`, which `api.c` uses to resample audio. The linked libraries differ per device (`NEXTUI_GL_LIBS`):
 
-- `tg5040-nextui`: `-lGLESv2`
-- `my355-nextui` and `h700-nextui`: `-lGLESv2 -lsamplerate`
-- `tg5050-nextui`: `-lGLESv2 -lmali -lsamplerate` (its `libGLESv2` is backed by a standalone mali blob that must be linked explicitly)
+- `tg5040-nextui` and `h700-nextui`: `-lGLESv2 -lsamplerate`
+- `tg5050-nextui` and `my355-nextui`: `-lGLESv2 -lmali -lsamplerate` (their `libGLESv2` is a stub backed by a standalone mali blob that must be linked explicitly)
 
 ## Building
 

--- a/docs/nextui.md
+++ b/docs/nextui.md
@@ -1,0 +1,56 @@
+# NextUI builds
+
+Some devices run NextUI, a fork of MinUI, instead of (or in addition to) MinUI. NextUI ships a different SDK, so those devices need a binary built against a NextUI toolchain. These NextUI-specific binaries carry a `-nextui` suffix in their platform id and artifact name.
+
+## Platform matrix
+
+| Platform id     | Firmware | Upstream repo              | Version / ref (Makefile var)          | Workspace dir | Toolchain image                       |
+|-----------------|----------|----------------------------|---------------------------------------|---------------|---------------------------------------|
+| `tg5040-nextui` | NextUI   | `loveRetro/NextUI`         | `v6.14.0` (`NEXTUI_VERSION`)          | `tg5040`      | `savant/minui-toolchain:tg5040-nextui` |
+| `my355-nextui`  | NextUI   | `loveRetro/NextUI`         | `my355-latest` (`MY355_NEXTUI_VERSION`) | `my355`     | `savant/minui-toolchain:my355-nextui`  |
+| `tg5050-nextui` | NextUI   | `loveRetro/NextUI`         | `v6.14.0` (`NEXTUI_VERSION`)          | `tg5050`      | `savant/minui-toolchain:tg5050-nextui` |
+| `h700-nextui`   | NextUI   | `pvaibhav/NextUI`          | `h700-rc3` (`H700_VERSION`)           | `h700`        | `savant/minui-toolchain:h700-nextui`   |
+
+`tg5040` and `my355` also have MinUI builds (`minui-list-tg5040`, `minui-list-my355`) since those devices run both firmwares. `tg5050` and `h700` are NextUI-only.
+
+The `my355` workspace only exists on the `my355-latest` branch of `loveRetro/NextUI` (no tagged release contains it), so it uses its own version variable.
+
+## How the build is wired
+
+The Makefile keeps the build platform id (`PLATFORM`) separate from the upstream workspace directory and the on-device id:
+
+- `WORKSPACE` is the upstream workspace directory name and the runtime device id. It equals `PLATFORM` for every platform except the `-nextui` variants, where it is the bare device (for example `PLATFORM=tg5040-nextui` builds `WORKSPACE=tg5040`).
+- `IS_NEXTUI` is set for NextUI platforms. It gates the `/opt/nextui` include and lib paths, the `-DPLATFORM_NEXTUI` define, the extra `config.c` source, and the GLES link flags.
+
+`-DPLATFORM` is compiled into the on-device `SYSTEM_PATH` and `USERDATA_PATH` (`.system/<PLATFORM>` and `.userdata/<PLATFORM>`), so it is driven by `WORKSPACE`. A `tg5040-nextui` binary therefore reports `tg5040` at runtime and resolves the same on-card paths as the device firmware.
+
+The only source-level NextUI difference is in `minui-list.c`: under `-DPLATFORM_NEXTUI`, `PLAT_isOnline` is mapped to `PWR_isOnline`, which NextUI's SDK uses for online detection.
+
+### GLES and audio libraries
+
+NextUI toolchains install `libmsettings` and the GLES stack under `/opt/nextui`. The linked libraries differ per device (`NEXTUI_GL_LIBS`):
+
+- `tg5040-nextui`: `-lGLESv2`
+- `my355-nextui` and `h700-nextui`: `-lGLESv2 -lsamplerate`
+- `tg5050-nextui`: `-lGLESv2 -lmali -lsamplerate` (its `libGLESv2` is backed by a standalone mali blob that must be linked explicitly)
+
+## Building
+
+Build a NextUI variant with its platform id inside the matching toolchain:
+
+```bash
+PLATFORM=tg5040-nextui make setup
+PLATFORM=tg5040-nextui make
+```
+
+This produces `minui-list-tg5040-nextui`.
+
+## Testing the wiring
+
+`tests/makefile.bats` asserts the per-platform Makefile wiring (upstream repo, version, workspace, `-DPLATFORM_NEXTUI`, device id, sources, and GLES libs) by introspecting the Makefile with `make print-<VAR> PLATFORM=<p>`. It needs neither a toolchain nor a cloned upstream tree:
+
+```bash
+bats tests/makefile.bats
+```
+
+The CI matrix builds every NextUI binary in its `savant/minui-toolchain:<device>-nextui` container, which is the integration test for the full compile and link.

--- a/tests/makefile.bats
+++ b/tests/makefile.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+#
+# Build-wiring tests for the Makefile.
+#
+# These assert how the Makefile resolves per-platform build variables, with a
+# focus on the NextUI-specific variants (issue 118). They introspect the
+# Makefile with `make print-<VAR> PLATFORM=<p>`, so they need neither a cross
+# toolchain nor a cloned upstream tree and run on any host with make.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+}
+
+# print-<VAR> for a platform; sets $status/$output/$lines via bats `run`.
+mk() { # <VAR> <PLATFORM>
+    run make --no-print-directory -C "$REPO_ROOT" "print-$1" PLATFORM="$2"
+    [ "$status" -eq 0 ]
+}
+
+# tg5040-nextui: NextUI build for the Trimui Brick/Smart Pro (also has a MinUI build)
+
+@test "tg5040-nextui uses the loveRetro NextUI upstream at the pinned tag" {
+    mk UPSTREAM_REPO tg5040-nextui
+    [ "$output" = "UPSTREAM_REPO=https://github.com/loveRetro/NextUI" ]
+    mk UPSTREAM_VERSION tg5040-nextui
+    [ "$output" = "UPSTREAM_VERSION=v6.14.0" ]
+}
+
+@test "tg5040-nextui builds the bare tg5040 workspace and is flagged NextUI" {
+    mk WORKSPACE tg5040-nextui
+    [ "$output" = "WORKSPACE=tg5040" ]
+    mk IS_NEXTUI tg5040-nextui
+    [ "$output" = "IS_NEXTUI=1" ]
+}
+
+@test "tg5040-nextui bakes the device id (not the -nextui variant) into -DPLATFORM" {
+    mk CFLAGS tg5040-nextui
+    [[ "$output" == *'-DPLATFORM_NEXTUI'* ]]
+    [[ "$output" == *'-DPLATFORM=\"tg5040\"'* ]]
+    [[ "$output" != *'-DPLATFORM=\"tg5040-nextui\"'* ]]
+}
+
+@test "tg5040-nextui compiles the tg5040 platform source and NextUI config" {
+    mk SOURCE tg5040-nextui
+    [[ "$output" == *'minui/workspace/tg5040/platform/platform.c'* ]]
+    [[ "$output" == *'minui/workspace/all/common/config.c'* ]]
+}
+
+@test "tg5040-nextui links GLESv2 only (no mali, no samplerate)" {
+    mk NEXTUI_GL_LIBS tg5040-nextui
+    [ "$output" = "NEXTUI_GL_LIBS=-lGLESv2" ]
+}
+
+@test "tg5040-nextui produces the -nextui artifact id" {
+    mk PLATFORM tg5040-nextui
+    [ "$output" = "PLATFORM=tg5040-nextui" ]
+}
+
+# my355-nextui: NextUI build for the Miyoo Flip (workspace lives on a branch)
+
+@test "my355-nextui uses loveRetro NextUI at the my355-latest branch" {
+    mk UPSTREAM_REPO my355-nextui
+    [ "$output" = "UPSTREAM_REPO=https://github.com/loveRetro/NextUI" ]
+    mk UPSTREAM_VERSION my355-nextui
+    [ "$output" = "UPSTREAM_VERSION=my355-latest" ]
+}
+
+@test "my355-nextui builds the bare my355 workspace with the device id" {
+    mk WORKSPACE my355-nextui
+    [ "$output" = "WORKSPACE=my355" ]
+    mk CFLAGS my355-nextui
+    [[ "$output" == *'-DPLATFORM=\"my355\"'* ]]
+    [[ "$output" == *'-DPLATFORM_NEXTUI'* ]]
+}
+
+@test "my355-nextui links samplerate but not mali" {
+    mk NEXTUI_GL_LIBS my355-nextui
+    [[ "$output" == *'-lGLESv2'* ]]
+    [[ "$output" == *'-lsamplerate'* ]]
+    [[ "$output" != *'-lmali'* ]]
+}
+
+# tg5050-nextui: NextUI-only device that needs the standalone mali blob
+
+@test "tg5050-nextui uses loveRetro NextUI and the tg5050 workspace" {
+    mk UPSTREAM_REPO tg5050-nextui
+    [ "$output" = "UPSTREAM_REPO=https://github.com/loveRetro/NextUI" ]
+    mk WORKSPACE tg5050-nextui
+    [ "$output" = "WORKSPACE=tg5050" ]
+}
+
+@test "tg5050-nextui links the mali blob explicitly" {
+    mk NEXTUI_GL_LIBS tg5050-nextui
+    [[ "$output" == *'-lmali'* ]]
+    [[ "$output" == *'-lsamplerate'* ]]
+}
+
+# h700-nextui: NextUI-only device sourced from the pvaibhav fork
+
+@test "h700-nextui uses the pvaibhav NextUI fork at the h700 tag" {
+    mk UPSTREAM_REPO h700-nextui
+    [ "$output" = "UPSTREAM_REPO=https://github.com/pvaibhav/NextUI" ]
+    mk UPSTREAM_VERSION h700-nextui
+    [ "$output" = "UPSTREAM_VERSION=h700-rc3" ]
+    mk WORKSPACE h700-nextui
+    [ "$output" = "WORKSPACE=h700" ]
+}
+
+@test "h700-nextui links samplerate but not mali" {
+    mk NEXTUI_GL_LIBS h700-nextui
+    [[ "$output" == *'-lsamplerate'* ]]
+    [[ "$output" != *'-lmali'* ]]
+}
+
+# regression: a plain MinUI platform is untouched by the NextUI wiring
+
+@test "tg5040 (MinUI) uses the shauninman upstream and is not a NextUI build" {
+    mk UPSTREAM_REPO tg5040
+    [ "$output" = "UPSTREAM_REPO=https://github.com/shauninman/MinUI" ]
+    mk IS_NEXTUI tg5040
+    [ "$output" = "IS_NEXTUI=" ]
+    mk WORKSPACE tg5040
+    [ "$output" = "WORKSPACE=tg5040" ]
+}
+
+@test "tg5040 (MinUI) defines neither PLATFORM_NEXTUI nor the config source" {
+    mk CFLAGS tg5040
+    [[ "$output" != *'-DPLATFORM_NEXTUI'* ]]
+    mk SOURCE tg5040
+    [[ "$output" != *'minui/workspace/all/common/config.c'* ]]
+}

--- a/tests/makefile.bats
+++ b/tests/makefile.bats
@@ -46,9 +46,11 @@ mk() { # <VAR> <PLATFORM>
     [[ "$output" == *'minui/workspace/all/common/config.c'* ]]
 }
 
-@test "tg5040-nextui links GLESv2 only (no mali, no samplerate)" {
+@test "tg5040-nextui links GLESv2 and samplerate (no mali)" {
     mk NEXTUI_GL_LIBS tg5040-nextui
-    [ "$output" = "NEXTUI_GL_LIBS=-lGLESv2" ]
+    [[ "$output" == *'-lGLESv2'* ]]
+    [[ "$output" == *'-lsamplerate'* ]]
+    [[ "$output" != *'-lmali'* ]]
 }
 
 @test "tg5040-nextui produces the -nextui artifact id" {
@@ -73,11 +75,10 @@ mk() { # <VAR> <PLATFORM>
     [[ "$output" == *'-DPLATFORM_NEXTUI'* ]]
 }
 
-@test "my355-nextui links samplerate but not mali" {
+@test "my355-nextui links the mali blob and samplerate" {
     mk NEXTUI_GL_LIBS my355-nextui
-    [[ "$output" == *'-lGLESv2'* ]]
+    [[ "$output" == *'-lmali'* ]]
     [[ "$output" == *'-lsamplerate'* ]]
-    [[ "$output" != *'-lmali'* ]]
 }
 
 # tg5050-nextui: NextUI-only device that needs the standalone mali blob


### PR DESCRIPTION
The `tg5040` (Trimui Brick/Smart Pro) and `my355` (Miyoo Flip) devices can run both MinUI and NextUI, but only MinUI binaries were produced for them, leaving NextUI users without a build that targets the NextUI SDK. This adds NextUI-specific `tg5040-nextui` and `my355-nextui` binaries built against the NextUI toolchains.

Because those two devices now produce both a MinUI and a NextUI binary, the NextUI builds carry a `-nextui` suffix in their platform id and artifact name. For consistency the existing NextUI-only `tg5050` and `h700` builds adopt the same scheme and are published as `minui-list-tg5050-nextui` and `minui-list-h700-nextui`. The previous `minui-list-tg5050` and `minui-list-h700` artifacts are no longer produced, so any consumer referencing those names should switch to the `-nextui` names. The NextUI SDK pin also moves to `v6.14.0`.

A NextUI binary continues to report the bare device id at runtime so it resolves the same on-card paths as the device firmware. The CI and release matrices build all four NextUI binaries, and a new `tests/makefile.bats` suite asserts that each platform resolves the correct upstream, toolchain, and link configuration.

Closes #118.
