### PR TITLE
feat: honor NextUI theming for nextui binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c list_theme.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(WORKSPACE)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(WORKSPACE)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(WORKSPACE)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c list_filter.c list_hint.c list_image.c list_keyboard.c list_nav.c list_scroll.c list_theme.c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(WORKSPACE)/platform/platform.c include/parson/parson.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # NextUI toolchains install libmsettings and the GLES stack to /opt/nextui.
   # api.c resamples audio through libsamplerate on every NextUI target. tg5050
@@ -143,6 +143,8 @@ test:
 	./tmp/list_filter_test
 	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_keyboard_test.c list_keyboard.c -o tmp/list_keyboard_test
 	./tmp/list_keyboard_test
+	$(TEST_CC) -std=gnu99 -Wall -Wextra -I. tests/list_theme_test.c list_theme.c -o tmp/list_theme_test
+	./tmp/list_theme_test
 
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Binaries are built against one of two firmwares. Most devices build against MinU
 - `tg5040` and `my355` run both firmwares, so they have a MinUI build (`minui-list-tg5040`, `minui-list-my355`) and a NextUI build (`minui-list-tg5040-nextui`, `minui-list-my355-nextui`).
 - `tg5050` and `h700` are NextUI-only and build as `minui-list-tg5050-nextui` and `minui-list-h700-nextui`.
 
-To build a NextUI variant, use its platform id inside the matching toolchain, for example `PLATFORM=tg5040-nextui make`. See [docs/nextui.md](docs/nextui.md) for the platform/toolchain matrix and how the NextUI builds are wired. For the native macOS build used by the test suite, see [docs/macos.md](docs/macos.md).
+The `-nextui` binaries honor the device's NextUI theme, re-coloring the list from the user's chosen theme colors and font instead of the fixed MinUI greyscale palette.
+
+To build a NextUI variant, use its platform id inside the matching toolchain, for example `PLATFORM=tg5040-nextui make`. See [docs/nextui.md](docs/nextui.md) for the platform/toolchain matrix, the theming details, and how the NextUI builds are wired. For the native macOS build used by the test suite, see [docs/macos.md](docs/macos.md).
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
 - [macos.md](macos.md) - building and running minui-list natively on macOS (used by the test suite)
-- [nextui.md](nextui.md) - NextUI-specific builds, the platform/toolchain matrix, and how they are wired
+- [nextui.md](nextui.md) - NextUI-specific builds, the platform/toolchain matrix, theming, and how they are wired
 
 The main [README](../README.md) covers usage, CLI flags, file formats, and the supported-platforms overview.

--- a/docs/nextui.md
+++ b/docs/nextui.md
@@ -24,7 +24,10 @@ The Makefile keeps the build platform id (`PLATFORM`) separate from the upstream
 
 `-DPLATFORM` is compiled into the on-device `SYSTEM_PATH` and `USERDATA_PATH` (`.system/<PLATFORM>` and `.userdata/<PLATFORM>`), so it is driven by `WORKSPACE`. A `tg5040-nextui` binary therefore reports `tg5040` at runtime and resolves the same on-card paths as the device firmware.
 
-The only source-level NextUI difference is in `minui-list.c`: under `-DPLATFORM_NEXTUI`, `PLAT_isOnline` is mapped to `PWR_isOnline`, which NextUI's SDK uses for online detection.
+The source-level NextUI differences all live in `minui-list.c`, gated by `-DPLATFORM_NEXTUI`:
+
+- `PLAT_isOnline` is mapped to `PWR_isOnline`, which NextUI's SDK uses for online detection.
+- the UI is re-colored from the user's NextUI theme (see [Theming](#theming) below).
 
 ### GLES and audio libraries
 
@@ -32,6 +35,26 @@ NextUI toolchains install `libmsettings` and the GLES stack under `/opt/nextui`.
 
 - `tg5040-nextui` and `h700-nextui`: `-lGLESv2 -lsamplerate`
 - `tg5050-nextui` and `my355-nextui`: `-lGLESv2 -lmali -lsamplerate` (their `libGLESv2` is a stub backed by a standalone mali blob that must be linked explicitly)
+
+## Theming
+
+NextUI lets the user pick theme colors and a font (stored in `minuisettings.txt`). The `-nextui` binaries honor that theme, so a `minui-list` page matches the rest of the NextUI menu instead of the fixed greyscale MinUI palette. MinUI and macOS builds are unaffected: every theme reference is confined to `#ifdef PLATFORM_NEXTUI` helpers in `minui-list.c`, so those builds still use the greyscale palette and compile unchanged.
+
+Nothing new has to be initialized. The existing `GFX_init(MODE_MAIN)` call already runs the NextUI SDK's `CFG_init`, which reads the theme and populates `THEME_COLOR1..7` (screen-mapped) and `THEME_COLOR1_255..7_255` (packed `0xRRGGBBAA`), the themed `font.*`, and the themed clear color. The app just references those globals when drawing. NextUI's color slots (`config.h`) map to the UI as follows:
+
+| Theme slot (default)              | Where it is used                                                        |
+|-----------------------------------|-------------------------------------------------------------------------|
+| `COLOR_MAIN` (white)              | the selected-row pill and the focused filter-keyboard key               |
+| `COLOR_ACCENT` (magenta)          | the filter match-highlight rectangle                                    |
+| `COLOR_ACCENT2` (dark navy)       | the option-value track pill, the keyboard input field, unfocused keys   |
+| `COLOR_LIST_TEXT` (white)         | unselected row text, option-value text, the title, keyboard input/labels |
+| `COLOR_LIST_TEXT_SELECTED` (black)| selected row text, match-highlight text, focused-key text               |
+| `COLOR_HINT` (white)              | hardware/button hints (already themed by the SDK's `GFX_blitButton*`)   |
+| `COLOR_BACKGROUND` (black)        | the default background fill, when no per-item background is set          |
+
+The disabled and header/unselectable rows keep static greys, matching NextUI's own menus. Fonts follow the theme automatically: when no `--font-*` override is given, `open_fonts()` falls back to the SDK `font.*`, which `GFX_init` loaded from the themed font. The background falls back to `COLOR_BACKGROUND` only when an item sets no `background_color`/`background_image`; explicit `--background-color`, JSON `background_color`, and `background_image` still override it. Under the default theme the result looks the same as the MinUI greyscale; the theme only diverges once the user customizes it.
+
+The row-color precedence (which text role a row uses) is factored into the SDL-free `list_theme.c` module and unit tested by `tests/list_theme_test.c` (run via `make test`). `tests/makefile.bats` asserts `list_theme.c` is compiled into every platform.
 
 ## Building
 

--- a/list_theme.c
+++ b/list_theme.c
@@ -1,0 +1,15 @@
+#include "list_theme.h"
+
+ListTextRole ListTheme_RowTextRole(int is_selected, int is_disabled, int is_muted)
+{
+    // a header/unselectable row is muted regardless of selection or disabled state
+    if (is_muted)
+        return LIST_TEXT_MUTED;
+
+    // the selected row draws on the selection pill
+    if (is_selected)
+        return is_disabled ? LIST_TEXT_SELECTED_DISABLED : LIST_TEXT_SELECTED;
+
+    // an unselected row uses the normal (or dimmed, when disabled) list text
+    return is_disabled ? LIST_TEXT_DISABLED : LIST_TEXT_NORMAL;
+}

--- a/list_theme.h
+++ b/list_theme.h
@@ -1,0 +1,39 @@
+#ifndef LIST_THEME_H
+#define LIST_THEME_H
+
+// list_theme provides the SDL-free decision behind which text color a list row
+// should use, given its selection and item state. Keeping it display-free means it
+// can be unit tested with the host compiler (see tests/list_theme_test.c); the
+// caller (minui-list.c) maps the returned role to an actual SDL_Color, choosing the
+// NextUI theme color under -DPLATFORM_NEXTUI or the greyscale palette otherwise.
+
+// ListTextRole enumerates the semantic text colors a list row can use. The color
+// values live in the caller; this only captures which role applies.
+typedef enum
+{
+    // unselected, enabled, selectable row (the normal list text)
+    LIST_TEXT_NORMAL = 0,
+    // unselected, disabled row (dimmed)
+    LIST_TEXT_DISABLED,
+    // header or unselectable row (muted), for any selection state
+    LIST_TEXT_MUTED,
+    // the currently selected, enabled row (drawn on the selection pill)
+    LIST_TEXT_SELECTED,
+    // the currently selected, disabled row
+    LIST_TEXT_SELECTED_DISABLED,
+} ListTextRole;
+
+// ListTheme_RowTextRole decides which text role a row should use.
+//
+// is_selected: whether this row is the currently selected row.
+// is_disabled: whether the item's disabled feature is set.
+// is_muted: whether the item is a header or unselectable.
+//
+// Precedence matches the existing inline logic in minui-list.c: a muted
+// (header/unselectable) row is always LIST_TEXT_MUTED regardless of selection or
+// disabled state; otherwise a selected row is LIST_TEXT_SELECTED (or
+// LIST_TEXT_SELECTED_DISABLED when disabled), and an unselected row is
+// LIST_TEXT_NORMAL (or LIST_TEXT_DISABLED when disabled).
+ListTextRole ListTheme_RowTextRole(int is_selected, int is_disabled, int is_muted);
+
+#endif // LIST_THEME_H

--- a/minui-list.c
+++ b/minui-list.c
@@ -25,6 +25,7 @@
 #include "list_keyboard.h"
 #include "list_nav.h"
 #include "list_scroll.h"
+#include "list_theme.h"
 
 // the largest image column width is a third of the screen width, per issue #13
 #define IMAGE_MAX_WIDTH_DIVISOR 3
@@ -38,6 +39,161 @@
 #ifdef PLATFORM_NEXTUI
 #define PLAT_isOnline PWR_isOnline
 #endif
+
+// Theme helpers. The -nextui builds honor the user's NextUI theme colors
+// (COLOR_MAIN..COLOR_BACKGROUND, exposed by the SDK as THEME_COLOR* /
+// THEME_COLOR*_255 after GFX_init loads the theme), while the MinUI/macOS builds
+// keep the greyscale palette. Every NextUI-only symbol (THEME_COLOR*,
+// uintToColour, GFX_blitPillDark/Color, RGB_WHITE) is confined to these helpers
+// behind PLATFORM_NEXTUI so the other builds compile unchanged. The mapping from
+// list row state to a text role lives in list_theme.c (unit tested); these helpers
+// turn a role or draw intent into the actual color/blit.
+
+// theme_row_text_color maps a list row's text role to its color. Only the normal
+// and selected roles are theme-driven; the muted/disabled greys are shared with
+// MinUI (NextUI keeps static greys for those too).
+static SDL_Color theme_row_text_color(ListTextRole role)
+{
+    switch (role)
+    {
+    case LIST_TEXT_SELECTED:
+#ifdef PLATFORM_NEXTUI
+        return uintToColour(THEME_COLOR5_255);
+#else
+        return COLOR_BLACK;
+#endif
+    case LIST_TEXT_NORMAL:
+#ifdef PLATFORM_NEXTUI
+        return uintToColour(THEME_COLOR4_255);
+#else
+        return COLOR_WHITE;
+#endif
+    case LIST_TEXT_DISABLED:
+        return (SDL_Color){TRIAD_DARK_GRAY};
+    case LIST_TEXT_SELECTED_DISABLED:
+        return (SDL_Color){TRIAD_LIGHT_GRAY};
+    case LIST_TEXT_MUTED:
+    default:
+        return COLOR_LIGHT_TEXT;
+    }
+}
+
+// theme_title_text_color returns the title color. Over a background image the
+// title stays white (drawn on a black pill for legibility over arbitrary art);
+// otherwise it follows the theme's list text color.
+static SDL_Color theme_title_text_color(bool has_bg_image)
+{
+    if (has_bg_image)
+        return COLOR_WHITE;
+#ifdef PLATFORM_NEXTUI
+    return uintToColour(THEME_COLOR4_255);
+#else
+    return COLOR_GRAY;
+#endif
+}
+
+// theme_accent_u32 returns the filter match-highlight fill color: the theme accent
+// under NextUI, the app's gold accent under MinUI.
+static uint32_t theme_accent_u32(SDL_Surface *dst)
+{
+#ifdef PLATFORM_NEXTUI
+    (void)dst;
+    return THEME_COLOR2;
+#else
+    return SDL_MapRGB(dst->format, TRIAD_FILTER_HIGHLIGHT);
+#endif
+}
+
+// theme_accent_text_color returns the text color drawn over the accent highlight.
+// There is no theme "text on accent" slot, so the selected-text foreground (the
+// theme's readable foreground) is the closest match under NextUI.
+static SDL_Color theme_accent_text_color(void)
+{
+#ifdef PLATFORM_NEXTUI
+    return uintToColour(THEME_COLOR5_255);
+#else
+    return COLOR_BLACK;
+#endif
+}
+
+// theme_background_u32 returns the default background fill. NextUI honors the
+// theme background; MinUI fills black. Explicit per-item background colors/images
+// still override this at the call site.
+static uint32_t theme_background_u32(SDL_Surface *dst)
+{
+#ifdef PLATFORM_NEXTUI
+    (void)dst;
+    return THEME_COLOR7;
+#else
+    return SDL_MapRGBA(dst->format, 0, 0, 0, 255);
+#endif
+}
+
+// blit_selected_pill draws the selection pill: tinted with the theme's main color
+// under NextUI, the plain white pill asset under MinUI.
+static void blit_selected_pill(int asset, SDL_Surface *dst, SDL_Rect *rect)
+{
+#ifdef PLATFORM_NEXTUI
+    GFX_blitPillDark(asset, dst, rect);
+#else
+    GFX_blitPill(asset, dst, rect);
+#endif
+}
+
+// blit_value_track_pill draws the darker full-width track behind a selected row's
+// option value: tinted with the theme's secondary accent under NextUI.
+static void blit_value_track_pill(int asset, SDL_Surface *dst, SDL_Rect *rect)
+{
+#ifdef PLATFORM_NEXTUI
+    GFX_blitPillColor(asset, dst, rect, THEME_COLOR3, RGB_WHITE);
+#else
+    GFX_blitPill(asset, dst, rect);
+#endif
+}
+
+// theme_kb_input_bg / theme_kb_input_text color the filter keyboard's input field
+// (secondary accent track with list text under NextUI).
+static uint32_t theme_kb_input_bg(SDL_Surface *dst)
+{
+#ifdef PLATFORM_NEXTUI
+    (void)dst;
+    return THEME_COLOR3;
+#else
+    return SDL_MapRGB(dst->format, TRIAD_DARK_GRAY);
+#endif
+}
+
+static SDL_Color theme_kb_input_text(void)
+{
+#ifdef PLATFORM_NEXTUI
+    return uintToColour(THEME_COLOR4_255);
+#else
+    return COLOR_WHITE;
+#endif
+}
+
+// theme_kb_key_bg / theme_kb_key_text color a keyboard key. A focused key mirrors
+// the selection pill (main + selected text); an unfocused key uses the secondary
+// accent track with the list text.
+static uint32_t theme_kb_key_bg(SDL_Surface *dst, bool focused)
+{
+#ifdef PLATFORM_NEXTUI
+    (void)dst;
+    return focused ? THEME_COLOR1 : THEME_COLOR3;
+#else
+    return focused ? SDL_MapRGB(dst->format, TRIAD_WHITE)
+                   : SDL_MapRGB(dst->format, TRIAD_DARK_GRAY);
+#endif
+}
+
+static SDL_Color theme_kb_key_text(bool focused)
+{
+#ifdef PLATFORM_NEXTUI
+    return focused ? uintToColour(THEME_COLOR5_255) : uintToColour(THEME_COLOR4_255);
+#else
+    return focused ? COLOR_BLACK : COLOR_WHITE;
+#endif
+}
 
 SDL_Surface *screen = NULL;
 
@@ -2321,20 +2477,25 @@ bool draw_background(SDL_Surface *screen, struct AppState *state)
     // nothing selected (e.g. an active filter matched no items): plain background
     if (state->list_state->selected < 0)
     {
-        SDL_FillRect(screen, NULL, SDL_MapRGBA(screen->format, 0, 0, 0, 255));
+        SDL_FillRect(screen, NULL, theme_background_u32(screen));
         return false;
     }
 
-    // render a background color
-    char hex_color[1024] = "#000000";
+    // render a background color. an explicit per-item or --background-color value
+    // (both populate features.background_color) wins; otherwise fall back to the
+    // theme background (black on MinUI, COLOR_BACKGROUND on NextUI).
     if (state->list_state->items[state->list_state->visible[state->list_state->selected]].features.background_color[0] != '\0')
     {
+        char hex_color[1024] = "#000000";
         strncpy(hex_color, state->list_state->items[state->list_state->visible[state->list_state->selected]].features.background_color, sizeof(hex_color));
+        SDL_Color background_color = hex_to_sdl_color(hex_color);
+        uint32_t color = SDL_MapRGBA(screen->format, background_color.r, background_color.g, background_color.b, 255);
+        SDL_FillRect(screen, NULL, color);
     }
-
-    SDL_Color background_color = hex_to_sdl_color(hex_color);
-    uint32_t color = SDL_MapRGBA(screen->format, background_color.r, background_color.g, background_color.b, 255);
-    SDL_FillRect(screen, NULL, color);
+    else
+    {
+        SDL_FillRect(screen, NULL, theme_background_u32(screen));
+    }
 
     bool should_draw_background_image = false;
     if (state->list_state->items[state->list_state->visible[state->list_state->selected]].features.background_image_exists && access(state->list_state->items[state->list_state->visible[state->list_state->selected]].features.background_image, F_OK) != -1)
@@ -2429,9 +2590,9 @@ static void draw_match_highlight(SDL_Surface *screen, TTF_Font *font,
         return;
 
     SDL_Rect hl = {base_x + prefix_w, base_y, match_w, match_h};
-    SDL_FillRect(screen, &hl, SDL_MapRGB(screen->format, TRIAD_FILTER_HIGHLIGHT));
+    SDL_FillRect(screen, &hl, theme_accent_u32(screen));
 
-    SDL_Surface *m = TTF_RenderUTF8_Blended(font, match, COLOR_BLACK);
+    SDL_Surface *m = TTF_RenderUTF8_Blended(font, match, theme_accent_text_color());
     if (m != NULL)
     {
         SDL_Rect mp = {base_x + prefix_w, base_y, m->w, m->h};
@@ -2450,13 +2611,13 @@ static void draw_filter_keyboard(SDL_Surface *screen, struct AppState *state)
 
     // input field background
     SDL_Rect input_bg = {SCALE1(PADDING), g.input_y, screen->w - SCALE1(PADDING) * 2, g.input_h};
-    SDL_FillRect(screen, &input_bg, SDL_MapRGB(screen->format, TRIAD_DARK_GRAY));
+    SDL_FillRect(screen, &input_bg, theme_kb_input_bg(screen));
 
     // current filter text, clipped to the field and tail-aligned so the most
     // recently typed characters stay visible
     if (state->filter_text[0] != '\0' && kb_font != NULL)
     {
-        SDL_Surface *input = TTF_RenderUTF8_Blended(kb_font, state->filter_text, COLOR_WHITE);
+        SDL_Surface *input = TTF_RenderUTF8_Blended(kb_font, state->filter_text, theme_kb_input_text());
         if (input != NULL)
         {
             int inner_x = SCALE1(PADDING + BUTTON_PADDING);
@@ -2522,13 +2683,12 @@ static void draw_filter_keyboard(SDL_Surface *screen, struct AppState *state)
                 cur_w,
                 g.key_size};
 
-            Uint32 bg = focused ? SDL_MapRGB(screen->format, TRIAD_WHITE)
-                                : SDL_MapRGB(screen->format, TRIAD_DARK_GRAY);
+            Uint32 bg = theme_kb_key_bg(screen, focused);
             SDL_FillRect(screen, &key_pos, bg);
 
             if (kb_font != NULL)
             {
-                SDL_Color tc = focused ? COLOR_BLACK : COLOR_WHITE;
+                SDL_Color tc = theme_kb_key_text(focused);
                 SDL_Surface *kt = TTF_RenderUTF8_Blended(kb_font, key, tc);
                 if (kt != NULL)
                 {
@@ -2641,11 +2801,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
         }
 
         // draw the title
-        SDL_Color text_color = COLOR_GRAY;
-        if (should_draw_background_image)
-        {
-            text_color = COLOR_WHITE;
-        }
+        SDL_Color text_color = theme_title_text_color(should_draw_background_image);
         SDL_Surface *text = TTF_RenderUTF8_Blended(state->fonts.medium, truncated_title_text, text_color);
         SDL_Rect pos = {
             title_x_pos,
@@ -2729,15 +2885,13 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             snprintf(display_text, sizeof(display_text), "%s", state->list_state->items[i].name);
         }
 
-        SDL_Color text_color = COLOR_WHITE;
-        if (state->list_state->items[i].features.disabled)
-        {
-            text_color = (SDL_Color){TRIAD_DARK_GRAY};
-        }
-        if (state->list_state->items[i].features.is_header || state->list_state->items[i].features.unselectable)
-        {
-            text_color = COLOR_LIGHT_TEXT;
-        }
+        // resolve the row text color from its state (selected/disabled/muted).
+        // ListTheme_RowTextRole captures the precedence; theme_row_text_color maps
+        // the role to the greyscale palette or, on -nextui builds, the theme colors.
+        SDL_Color text_color = theme_row_text_color(ListTheme_RowTextRole(
+            j == selected_row,
+            state->list_state->items[i].features.disabled,
+            state->list_state->items[i].features.is_header || state->list_state->items[i].features.unselectable));
 
         int color_placeholder_height;
         TTF_SizeUTF8(state->fonts.medium, " ", NULL, &color_placeholder_height);
@@ -2820,16 +2974,12 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
 
         if (j == selected_row)
         {
-            text_color = COLOR_BLACK;
+            // text_color is already resolved above (with is_selected set); the
+            // selected branch only records the row's state for input handling.
             current_item_is_enabled = state->list_state->items[i].features.disabled;
-            if (state->list_state->items[i].features.disabled)
-            {
-                text_color = (SDL_Color){TRIAD_LIGHT_GRAY};
-            }
             if (state->list_state->items[i].features.is_header || state->list_state->items[i].features.unselectable)
             {
                 current_item_is_header = true;
-                text_color = COLOR_LIGHT_TEXT;
             }
             if (state->list_state->items[i].features.can_disable)
             {
@@ -2876,10 +3026,10 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
 
             if (strcmp(display_selected_text, "") != 0)
             {
-                GFX_blitPill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), screen->w - SCALE1(PADDING + BUTTON_MARGIN) - image_col_space, SCALE1(PILL_SIZE)});
+                blit_value_track_pill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), screen->w - SCALE1(PADDING + BUTTON_MARGIN) - image_col_space, SCALE1(PILL_SIZE)});
             }
 
-            GFX_blitPill(ASSET_WHITE_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), pill_width, SCALE1(PILL_SIZE)});
+            blit_selected_pill(ASSET_WHITE_PILL, screen, &(SDL_Rect){pill_x_pos, SCALE1(PADDING + (j * PILL_SIZE) + initial_list_y_padding), pill_width, SCALE1(PILL_SIZE)});
         }
 
         SDL_Surface *text;
@@ -3001,11 +3151,10 @@ void draw_screen(SDL_Surface *screen, struct AppState *state, int ow, bool shoul
             initial_cube_x_pos = screen->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space;
             if (j != 0 || strlen(state->title) > 0)
             {
-                SDL_Color selected_text_color = COLOR_WHITE;
-                if (state->list_state->items[i].features.disabled || state->list_state->items[i].features.unselectable)
-                {
-                    selected_text_color = COLOR_LIGHT_TEXT;
-                }
+                SDL_Color selected_text_color = theme_row_text_color(
+                    (state->list_state->items[i].features.disabled || state->list_state->items[i].features.unselectable)
+                        ? LIST_TEXT_MUTED
+                        : LIST_TEXT_NORMAL);
                 SDL_Surface *selected_text;
                 selected_text = TTF_RenderUTF8_Blended(state->fonts.large, display_selected_text, selected_text_color);
                 pos = (SDL_Rect){screen->w - selected_text->w - SCALE1(PADDING + BUTTON_PADDING) - color_box_space - image_col_space, pos.y, selected_text->w, selected_text->h};

--- a/tests/list_theme_test.c
+++ b/tests/list_theme_test.c
@@ -1,0 +1,76 @@
+// Unit tests for the pure list text-role decision helper. These have no
+// SDL/display dependencies, so they run headless with the host compiler via
+// `make test`. The caller (minui-list.c) maps the returned role to an actual
+// SDL_Color (NextUI theme color or the greyscale palette).
+
+#include "list_theme.h"
+
+#include <stdio.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected, msg)                                         \
+    do                                                                          \
+    {                                                                           \
+        checks++;                                                               \
+        int _a = (actual);                                                      \
+        int _e = (expected);                                                    \
+        if (_a != _e)                                                           \
+        {                                                                       \
+            failures++;                                                         \
+            fprintf(stderr, "FAIL: %s (expected %d, got %d)\n", (msg), _e, _a); \
+        }                                                                       \
+    } while (0)
+
+// an unselected, enabled, selectable row uses the normal list text
+static void test_normal_row(void)
+{
+    CHECK_EQ(ListTheme_RowTextRole(0, 0, 0), LIST_TEXT_NORMAL, "unselected enabled -> normal");
+}
+
+// an unselected, disabled row is dimmed
+static void test_disabled_row(void)
+{
+    CHECK_EQ(ListTheme_RowTextRole(0, 1, 0), LIST_TEXT_DISABLED, "unselected disabled -> disabled");
+}
+
+// the selected, enabled row draws on the selection pill
+static void test_selected_row(void)
+{
+    CHECK_EQ(ListTheme_RowTextRole(1, 0, 0), LIST_TEXT_SELECTED, "selected enabled -> selected");
+}
+
+// the selected, disabled row
+static void test_selected_disabled_row(void)
+{
+    CHECK_EQ(ListTheme_RowTextRole(1, 1, 0), LIST_TEXT_SELECTED_DISABLED, "selected disabled -> selected disabled");
+}
+
+// a muted (header/unselectable) row wins over selection and disabled state, so it
+// always resolves to LIST_TEXT_MUTED
+static void test_muted_wins(void)
+{
+    CHECK_EQ(ListTheme_RowTextRole(0, 0, 1), LIST_TEXT_MUTED, "unselected muted -> muted");
+    CHECK_EQ(ListTheme_RowTextRole(0, 1, 1), LIST_TEXT_MUTED, "unselected disabled muted -> muted");
+    CHECK_EQ(ListTheme_RowTextRole(1, 0, 1), LIST_TEXT_MUTED, "selected muted -> muted");
+    CHECK_EQ(ListTheme_RowTextRole(1, 1, 1), LIST_TEXT_MUTED, "selected disabled muted -> muted");
+}
+
+int main(void)
+{
+    test_normal_row();
+    test_disabled_row();
+    test_selected_row();
+    test_selected_disabled_row();
+    test_muted_wins();
+
+    if (failures == 0)
+    {
+        printf("ok - all %d checks passed\n", checks);
+        return 0;
+    }
+
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/tests/makefile.bats
+++ b/tests/makefile.bats
@@ -130,3 +130,14 @@ mk() { # <VAR> <PLATFORM>
     mk SOURCE tg5040
     [[ "$output" != *'minui/workspace/all/common/config.c'* ]]
 }
+
+# issue 131: the list_theme module (which drives NextUI theming via a pure text-role
+# decision) is platform-agnostic and must be compiled into every binary, not just the
+# NextUI ones.
+
+@test "list_theme.c is compiled for both MinUI and NextUI builds" {
+    mk SOURCE tg5040
+    [[ "$output" == *'list_theme.c'* ]]
+    mk SOURCE tg5040-nextui
+    [[ "$output" == *'list_theme.c'* ]]
+}


### PR DESCRIPTION
The `-nextui` binaries now re-color the list UI - the selected pill, list and selected text, the filter match highlight, the on-screen filter keyboard, and the default background - from the user's NextUI theme colors, and follow the themed font, so a `minui-list` page matches the rest of the NextUI menu instead of the fixed MinUI greyscale palette. The MinUI and macOS builds keep the greyscale palette and are unchanged.

Closes #131.